### PR TITLE
feat(docs): add agent_strategies.md

### DIFF
--- a/docs/agent_strategies.md
+++ b/docs/agent_strategies.md
@@ -1,0 +1,98 @@
+# QuantaTissu Agentic Development Roadmap
+
+This document outlines a strategic roadmap for evolving QuantaTissu from a foundational language model into a sophisticated, agentic coding assistant capable of understanding, planning, and executing complex software development tasks.
+
+## Introduction
+
+The goal is to transform QuantaTissu into an autonomous agent that can interact with a development environment to write, debug, and test code. This requires augmenting the core language model with capabilities for reasoning, tool use, and self-correction. This evolution will proceed in two major phases: enhancing the foundational model and then building agentic capabilities on top of it.
+
+---
+
+## Phase 1: Foundational Model Enhancement
+
+Before QuantaTissu can function as an agent, its core language model must be powerful, robust, and specialized for code. The focus of this phase is to elevate the model from a toy project to a capable code LLM.
+
+### 1.1. Implement a Full-Scale Training Pipeline
+-   **Objective**: Build the infrastructure to train QuantaTissu on a large-scale dataset.
+-   **Key Actions**:
+    -   Implement backpropagation to enable gradient-based learning.
+    -   Integrate a modern optimizer like AdamW.
+    -   Develop a data loading and preprocessing pipeline for handling massive code datasets (e.g., The Stack).
+    -   Implement a robust training loop with support for checkpointing, logging, and metrics tracking.
+
+### 1.2. Upgrade Model Architecture and Tokenization
+-   **Objective**: Modernize the model architecture for better performance and scalability.
+-   **Key Actions**:
+    -   **Scale Up**: Increase model depth (more transformer blocks) and width (`d_model`) significantly.
+    -   **Tokenizer**: Replace the basic word-level tokenizer with a **Byte-Pair Encoding (BPE)** tokenizer trained on a large code corpus. This is critical for handling the vast and complex vocabulary of programming languages.
+    -   **Efficiency**: Implement **KV Caching** and other optimizations to ensure efficient inference, which is crucial for an interactive agent.
+
+### 1.3. Establish Rigorous Evaluation
+-   **Objective**: Develop a framework for measuring the model's coding capabilities.
+-   **Key Actions**:
+    -   Implement standard code generation benchmarks (e.g., HumanEval, MBPP).
+    -   Set up an evaluation suite to continuously track performance on tasks like code completion, bug fixing, and test generation.
+
+---
+
+## Phase 2: Developing Agentic Capabilities
+
+With a strong foundation, the next step is to build the agentic framework that allows the model to act.
+
+### 2.1. Tool Integration (Tool-Use)
+-   **Objective**: Enable the model to interact with a developer's environment.
+-   **Key Actions**:
+    -   **Develop a Tool API**: Create a simple, robust interface that allows the model to issue commands.
+    -   **Implement Core Tools**:
+        -   `read_file(path)`: To read existing code.
+        -   `write_file(path, content)`: To create or modify files.
+        -   `run_shell(command)`: To execute shell commands for compilation, running tests, etc.
+    -   **Fine-tuning for Tool Use**: Fine-tune the model on examples of "thinking" and "tool invocation" to teach it how to request actions.
+
+### 2.2. Planning and Reasoning Engine
+-   **Objective**: Give the model the ability to break down high-level goals into executable steps.
+-   **Key Actions**:
+    -   **Implement a Planning Module**: Start with simple prompting techniques like **Chain of Thought (CoT)** where the model "thinks out loud" to structure its plan.
+    -   **Advanced Planning**: Explore more complex strategies like **Tree of Thoughts (ToT)**, allowing the model to explore multiple plans and self-correct.
+    -   **State Management**: Develop a system for the agent to maintain an understanding of its current state (files open, recent actions, etc.).
+
+### 2.3. Feedback and Self-Correction Loop
+-   **Objective**: Create a mechanism for the agent to learn from its mistakes in real-time.
+-   **Key Actions**:
+    -   **Output Parsing**: Implement parsers to capture the output of tools (e.g., compiler errors, test failures).
+    -   **Self-Correction Prompting**: Develop prompts that feed back the error messages to the model and ask it to generate a fix. For example: "Your previous code failed with the following error: `[error message]`. Please analyze the error and provide a corrected version of the file."
+
+---
+
+## Key Challenges and Mitigations
+
+| Challenge | Mitigation Strategies |
+| :--- | :--- |
+| **Computational Resources** | **Start Small**: Begin with smaller-scale models to iterate quickly.<br>**Efficient Training**: Explore techniques like LoRA for fine-tuning.<br>**Cloud Resources**: Utilize cloud platforms for scalable training. |
+| **High-Quality Code Data** | **Curated Datasets**: Focus on high-quality, well-documented code repositories.<br>**Data Cleaning**: Implement aggressive filtering and cleaning pipelines.<br>**Synthetic Data**: Generate synthetic examples of planning and tool use. |
+| **Safety and Reliability** | **Sandboxing**: Run the agent in a secure, containerized environment to prevent unintended side effects.<br>**User Confirmation**: Require user approval for potentially destructive actions (e.g., deleting files, running risky commands).<br>**Limited Permissions**: Grant the agent minimal necessary permissions. |
+| **Scalability** | **Incremental Development**: Start with narrow, well-defined tasks (e.g., "fix this specific linting error") before tackling open-ended problems.<br>**Modular Design**: Keep the agent's components (planning, execution, memory) modular and independently improvable. |
+
+---
+
+## High-Level Roadmap
+
+-   **Q1-Q2**: **Foundational Model Development**.
+    -   Complete the training pipeline and tokenizer.
+    -   Train a baseline code model (e.g., 1B parameters).
+    -   Set up HumanEval and MBPP evaluation.
+
+-   **Q3**: **Initial Agent and Tool Integration**.
+    -   Implement the core tool API (file I/O, shell).
+    -   Fine-tune the model for basic tool use.
+    -   Develop a simple CoT-based planning module.
+
+-   **Q4**: **Self-Correction and Advanced Planning**.
+    -   Implement the feedback loop for parsing errors.
+    -   Begin experiments with more advanced planning techniques.
+    -   Launch an internal alpha for dogfooding on simple tasks.
+
+-   **Year 2 and Beyond**: **Scaling and Refinement**.
+    -   Scale up the model size and training data.
+    -   Expand the toolset and tackle more complex tasks.
+    -   Improve reliability and user experience based on feedback.


### PR DESCRIPTION
I've added a new documentation file, `docs/agent_strategies.md`.

This file outlines a strategic roadmap for evolving QuantaTissu from a foundational language model into a sophisticated, agentic coding assistant. It covers a phased approach, key challenges, and potential mitigations.