### PR TITLE
Add unit and BDD tests for tisslang_parser

### DIFF
--- a/tests/features/tisslang_parser.feature
+++ b/tests/features/tisslang_parser.feature
@@ -1,0 +1,101 @@
+Feature: TissLang Parser
+
+  Scenario: Parsing a simple TissLang script
+    Given a TissLang script:
+      """
+      TASK "A simple task"
+      """
+    When I parse the script
+    Then the AST should be:
+      """
+      [
+        {
+          "type": "TASK",
+          "description": "A simple task"
+        }
+      ]
+      """
+
+  Scenario: Parsing a STEP with a RUN command
+    Given a TissLang script:
+      """
+      STEP "Run a command" {
+        RUN "echo 'Hello, BDD!'"
+      }
+      """
+    When I parse the script
+    Then the AST should be:
+      """
+      [
+        {
+          "type": "STEP",
+          "description": "Run a command",
+          "commands": [
+            {
+              "type": "RUN",
+              "command": "echo 'Hello, BDD!'"
+            }
+          ]
+        }
+      ]
+      """
+
+  Scenario: Parsing a WRITE command
+    Given a TissLang script:
+      """
+      STEP "Write to a file" {
+        WRITE "greetings.txt" <<EOF
+      Hello from TissLang!
+      This is a test.
+      EOF
+      }
+      """
+    When I parse the script
+    Then the AST should be:
+      """
+      [
+        {
+          "type": "STEP",
+          "description": "Write to a file",
+          "commands": [
+            {
+              "type": "WRITE",
+              "path": "greetings.txt",
+              "language": "EOF",
+              "content": "Hello from TissLang!\nThis is a test."
+            }
+          ]
+        }
+      ]
+      """
+
+  Scenario: Parsing a script with multiple commands
+    Given a TissLang script:
+      """
+      TASK "A complex task with multiple steps"
+
+      SETUP {
+        RUN "mkdir -p temp"
+      }
+
+      STEP "First step" {
+        READ "input.txt" AS input_data
+        RUN "process_data.py --input={{input_data}}"
+      }
+
+      STEP "Second step" {
+        ASSERT LAST_RUN.EXIT_CODE == 0
+      }
+      """
+    When I parse the script
+    Then the AST should have 4 top-level nodes
+
+  Scenario: Parsing a script with a syntax error
+    Given a TissLang script:
+      """
+      STEP "This will fail" {
+        RUN "some command"
+      # Missing closing brace
+      """
+    When I parse the script
+    Then parsing should fail with an error containing "Unexpected end of script"

--- a/tests/test_tisslang_parser.py
+++ b/tests/test_tisslang_parser.py
@@ -1,0 +1,119 @@
+import unittest
+import sys
+import os
+
+# Add the project root to the Python path
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from quanta_tissu.scripts.tisslang_parser import TissLangParser, TissLangParserError
+
+class TestTissLangParser(unittest.TestCase):
+
+    def test_parse_task(self):
+        parser = TissLangParser()
+        script = 'TASK "This is a test task"'
+        expected_ast = [{'type': 'TASK', 'description': 'This is a test task'}]
+        ast = parser.parse(script)
+        self.assertEqual(ast, expected_ast)
+
+    def test_parse_step(self):
+        parser = TissLangParser()
+        script = '''
+        STEP "This is a test step" {
+            RUN "echo 'hello'"
+        }
+        '''
+        expected_ast = [{
+            'type': 'STEP',
+            'description': 'This is a test step',
+            'commands': [{'type': 'RUN', 'command': "echo 'hello'"}]
+        }]
+        ast = parser.parse(script)
+        self.assertEqual(ast, expected_ast)
+
+    def test_parse_run(self):
+        parser = TissLangParser()
+        script = '''
+        STEP "Run a command" {
+            RUN "ls -l"
+        }
+        '''
+        expected_ast = [{
+            'type': 'STEP',
+            'description': 'Run a command',
+            'commands': [{'type': 'RUN', 'command': 'ls -l'}]
+        }]
+        ast = parser.parse(script)
+        self.assertEqual(ast, expected_ast)
+
+    def test_parse_write(self):
+        parser = TissLangParser()
+        script = '''
+        STEP "Write a file" {
+            WRITE "test.txt" <<EOF
+            Hello, world!
+            EOF
+        }
+        '''
+        expected_ast = [{
+            'type': 'STEP',
+            'description': 'Write a file',
+            'commands': [{'type': 'WRITE', 'path': 'test.txt', 'language': 'EOF', 'content': 'Hello, world!'}]
+        }]
+        ast = parser.parse(script)
+        self.assertEqual(ast, expected_ast)
+
+    def test_parse_read(self):
+        parser = TissLangParser()
+        script = '''
+        STEP "Read a file" {
+            READ "test.txt" AS my_var
+        }
+        '''
+        expected_ast = [{
+            'type': 'STEP',
+            'description': 'Read a file',
+            'commands': [{'type': 'READ', 'path': 'test.txt', 'variable': 'my_var'}]
+        }]
+        ast = parser.parse(script)
+        self.assertEqual(ast, expected_ast)
+
+    def test_parse_assert(self):
+        parser = TissLangParser()
+        script = '''
+        STEP "Assert a condition" {
+            ASSERT LAST_RUN.EXIT_CODE == 0
+        }
+        '''
+        expected_ast = [{
+            'type': 'STEP',
+            'description': 'Assert a condition',
+            'commands': [{'type': 'ASSERT', 'condition': 'LAST_RUN.EXIT_CODE == 0'}]
+        }]
+        ast = parser.parse(script)
+        self.assertEqual(ast, expected_ast)
+
+    def test_parse_setup(self):
+        parser = TissLangParser()
+        script = '''
+        SETUP {
+            RUN "pip install -r requirements.txt"
+        }
+        '''
+        expected_ast = [{
+            'type': 'SETUP',
+            'commands': [{'type': 'RUN', 'command': 'pip install -r requirements.txt'}]
+        }]
+        ast = parser.parse(script)
+        self.assertEqual(ast, expected_ast)
+
+    def test_unclosed_block(self):
+        parser = TissLangParser()
+        script = '''
+        STEP "This step is not closed" {
+        '''
+        with self.assertRaises(TissLangParserError):
+            parser.parse(script)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This change adds new unit and BDD tests for the `tisslang_parser`.

The new unit tests cover the basic functionality of the parser, including parsing of all TissLang commands.

The new BDD tests cover the same functionality, but in a more high-level, behavior-driven way.