### PR TITLE
feat: Add TissDB vision document

### DIFF
--- a/docs/tissdb_vision.md
+++ b/docs/tissdb_vision.md
@@ -1,0 +1,35 @@
+# TissDB Vision: A NoSQL Database on TissLang Principles
+
+## 1. Introduction: The Vision for TissDB
+
+TissDB is a conceptual next-generation NoSQL database designed around the principles of **TissLang**, a language paradigm that models data structures and interactions based on the biological concept of living tissue. Our vision is to create a database that is not just a passive repository of information but a dynamic, resilient, and self-organizing system that grows and adapts with the data it holds.
+
+TissDB will provide unparalleled flexibility, scalability, and robustness by treating data as interconnected "cells" that form complex "tissues," enabling organic data evolution and emergent data structures.
+
+## 2. Core Principles of TissLang
+
+TissLang is founded on three core principles that mimic biological tissues:
+
+*   **Cellular Data Atoms (Encapsulation):** The fundamental unit of data is a "cell," an atomic, self-contained entity that encapsulates its own data and logic. Each cell is immutable, and changes result in the creation of new cells, preserving a complete history of state.
+*   **Inter-Cellular Adhesion (Connections):** Cells are not isolated. They form relationships with other cells through "adhesion bonds," which are strongly-typed, bidirectional links. These bonds define the structure of the data "tissue" and are as important as the cells themselves.
+*   **Homeostasis and Adaptation (Self-Healing & Evolution):** Data tissues are designed to be self-healing. The database can automatically detect and repair inconsistencies or "damage" to the data structure. Furthermore, tissues can adapt over time, allowing for schema evolution without downtime or complex migrations.
+
+## 3. TissDB: The Database Implementation
+
+TissDB translates the TissLang principles into a distributed NoSQL database with the following characteristics:
+
+*   **Data Model:** A graph-based model where "cells" are nodes and "adhesion bonds" are edges. However, unlike traditional graph databases, TissDB's model includes cellular logic, allowing for more complex, active data behaviors.
+*   **Architecture:** A decentralized, peer-to-peer architecture where each node in the cluster holds a partition of the data tissue. The system is designed for high availability and fault tolerance, maintaining data integrity even with network partitions (homeostasis).
+*   **Querying:** A declarative query language based on TissLang that allows for traversing the data tissue through its adhesion bonds and querying the state of cells. Queries will be efficient and expressive, enabling complex pattern matching.
+*   **Transactions:** TissDB will support ACID-like transactions at the "tissue" level, ensuring that a series of operations that modify a data tissue are applied atomically.
+
+## 4. Key Features
+
+*   **Organic Scalability:** Add new nodes to the cluster, and the data tissue will naturally grow to inhabit them.
+*   **Built-in Versioning:** The immutable nature of cells provides a complete, auditable history of every piece of data.
+*   **Active Data Structures:** Embed logic within data cells to create smart data that can react to changes or queries.
+*   **Resilient by Design:** The self-healing properties of data tissues ensure high data integrity and availability.
+
+## 5. Conclusion
+
+TissDB, guided by the principles of TissLang, represents a new way of thinking about data. By moving from inert records to living, interconnected data tissues, we aim to build a database that is more intuitive, powerful, and resilient for the next generation of applications.


### PR DESCRIPTION
This commit introduces the TissDB vision document, which outlines the conceptual framework for a new NoSQL database based on the principles of TissLang.

The document is located at `docs/tissdb_vision.md` and includes:
- The core vision for TissDB.
- The foundational principles of TissLang.
- The proposed database architecture and features.

This document serves as a foundational piece for the future development of TissDB.