### PR TITLE
Fix compilation errors in lsm_tree.h

### DIFF
--- a/tissdb/storage/lsm_tree.h
+++ b/tissdb/storage/lsm_tree.h
@@ -7,6 +7,8 @@
 #include <vector>
 
 #include "collection.h"
+#include "../common/schema.h"
+#include "transaction_manager.h"
 
 namespace TissDB {
 namespace Storage {


### PR DESCRIPTION
Add missing include directives for `Schema` and `Transactions` to `tissdb/storage/lsm_tree.h`.

These changes are intended to fix the initial compilation errors encountered when trying to build the `tissdb` server.

NOTE: Due to a persistent environmental issue where the `tissdb` directory is inaccessible from the bash shell, these changes could not be compiled or tested. The build process is currently blocked.