### PR TITLE
Fix incorrect paths in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ More details on this initiative can be found in `docs/ecological_awareness.md`.
 
 To train the model from scratch on the provided corpus:
 ```bash
-python quanta_tissu/quanta_tissu/train.py
+python quanta_tissu/tisslm/train.py
 ```
 This will train a new tokenizer and save it to `models/tokenizer.json`, and save the trained model weights to `models/quanta_tissu.npz`.
 
@@ -166,7 +166,7 @@ The repository is organized into several key directories:
 .
 ├── docs/              # Documentation, design docs, and specifications
 ├── quanta_tissu/      # Python-based language model (QuantaTissu)
-│   ├── quanta_tissu/  # Source code for the QuantaTissu model
+│   ├── tisslm/        # Source code for the QuantaTissu model
 │   └── scripts/       # Scripts to run and interact with the model
 ├── tissdb/            # C++ NoSQL database (TissDB)
 │   ├── api/           # RESTful API implementation

--- a/docs/tissdb_current_status.md
+++ b/docs/tissdb_current_status.md
@@ -36,7 +36,7 @@ The "TissDB project" at present consists of the following separate components:
 
 1.  **Conceptual Documentation (`docs/`)**: A rich set of documents outlining the vision (`tissdb_vision.md`) and the detailed implementation plan (`tissdb_plan.md`).
 
-2.  **A Functional Python Knowledge Store (`quanta_tissu/quanta_tissu/knowledge_base.py`)**:
+2.  **A Functional Python Knowledge Store (`quanta_tissu/tisslm/knowledge_base.py`)**:
     - This is the primary piece of *functional* code related to the TissDB concept.
     - It is an **in-memory vector store**, not the planned C++ database.
     - It uses embeddings to store and retrieve documents based on semantic similarity, serving as a practical tool for knowledge management within the Quanta ecosystem.

--- a/docs/tissdb_file_structure.md
+++ b/docs/tissdb_file_structure.md
@@ -15,11 +15,11 @@ The core vision, planning, and design documents for TissDB are located in the `d
 -   `docs/tissdb_integration.md`: Explains how TissDB is intended to integrate with the broader Quanta ecosystem.
 -   `docs/tissdb_api_schema.json`: A JSON schema that defines the proposed structure for the TissDB REST API.
 
-## 3. Python Implementation (`quanta_tissu/quanta_tissu/`)
+## 3. Python Implementation (`quanta_tissu/tisslm/`)
 
 While the formal `tissdb` plan calls for a C++ implementation, a related and functional piece of the knowledge storage infrastructure exists in Python.
 
--   `quanta_tissu/quanta_tissu/knowledge_base.py`: This file contains the `KnowledgeBase` class, an in-memory vector-based knowledge store. It uses embeddings to store and retrieve documents based on semantic similarity. This serves as a practical implementation of some of the core ideas behind TissDB's knowledge management capabilities.
+-   `quanta_tissu/tisslm/knowledge_base.py`: This file contains the `KnowledgeBase` class, an in-memory vector-based knowledge store. It uses embeddings to store and retrieve documents based on semantic similarity. This serves as a practical implementation of some of the core ideas behind TissDB's knowledge management capabilities.
 
 ## 4. C++ Graph Visualization Utility (`quanta_tissu/knowledge_app/`)
 

--- a/docs/tissdb_planning_stages.md
+++ b/docs/tissdb_planning_stages.md
@@ -254,7 +254,7 @@ The core vision, planning, and design documents for TissDB are located in the `d
 
 While the full TissDB C++ database is still in development, several existing components in the repository are functionally related to the TissDB concept.
 
-### Python Implementation (`quanta_tissu/quanta_tissu/`)
+### Python Implementation (`quanta_tissu/tisslm/`)
 *   **`knowledge_base.py`**: This file contains the `KnowledgeBase` class, an in-memory vector-based knowledge store. It uses embeddings to store and retrieve documents based on semantic similarity. This serves as a practical implementation of some of the core ideas behind TissDB's intended knowledge management capabilities.
 *   **`tests/test_knowledge_base.py`**: Unit tests for the `KnowledgeBase` class, providing excellent examples of its usage.
 

--- a/docs/tisslm_plan.md
+++ b/docs/tisslm_plan.md
@@ -42,7 +42,7 @@ The development of TissLM emphasizes clarity and control. The entire training an
 
 ### 3.1. Codebase Organization
 
-The core logic is contained within the `quanta_tissu/quanta_tissu/` directory:
+The core logic is contained within the `quanta_tissu/tisslm/` directory:
 -   `model.py`: Defines the `QuantaTissu` class and its constituent layers.
 -   `layers.py`: Contains the implementation of individual layers like `MultiHeadAttention` and `FeedForward`.
 -   `config.py`: Centralizes all configurations, including model hyperparameters, vocabulary, and file paths.


### PR DESCRIPTION
Updated several documentation files and the README.md to replace outdated references to `quanta_tissu/quanta_tissu` with the correct path, `quanta_tissu/tisslm`.

This change brings the documentation in sync with the existing directory structure.