### PR TITLE
feat: Add BDD tests for TissDB and TissLM integration

### DIFF
--- a/tests/bdd_runner.py
+++ b/tests/bdd_runner.py
@@ -76,6 +76,7 @@ class BDDRunner:
         from tests.features.steps import test_database_steps
         from tests.features.steps import test_parser_steps
         from tests.features.steps import test_model_integration_steps
+        from tests.features.steps import test_integration_steps
         test_kv_cache_steps.register_steps(self)
         test_tokenizer_steps.register_steps(self)
         test_predict_steps.register_steps(self)
@@ -84,6 +85,7 @@ class BDDRunner:
         test_database_steps.register_steps(self)
         test_parser_steps.register_steps(self)
         test_model_integration_steps.register_steps(self)
+        test_integration_steps.register_steps(self)
         print("BDD Runner: All steps registered.")
         sys.stdout.flush()
 

--- a/tests/features/integration.feature
+++ b/tests/features/integration.feature
@@ -1,0 +1,40 @@
+Feature: TissDB and TissLM Integration
+
+  This feature tests the integration points between TissDB and TissLM,
+  specifically focusing on the Retrieval-Augmented Generation (RAG) pipeline
+  where TissLM retrieves contextual information from TissDB.
+
+  Scenario: TissLM KnowledgeBase retrieves context from TissDB for a user prompt
+    Given a running TissDB instance
+    And a TissDB collection named "knowledge_articles" is available for TissLM
+    And the "knowledge_articles" collection contains a document with ID "lsm_doc" and content {"title": "LSM Tree", "body": "A Log-Structured Merge-Tree is a data structure designed for efficient writes."}
+    And the "knowledge_articles" collection contains a document with ID "b_tree_doc" and content {"title": "B-Tree", "body": "A B-Tree is a self-balancing tree data structure that maintains sorted data."}
+
+    When the TissLM receives a user prompt "Tell me about LSM Trees"
+    And the TissLM KnowledgeBase formulates a TissQL query "SELECT body FROM knowledge_articles WHERE title = 'LSM Tree'"
+    And the KnowledgeBase executes the query against the "knowledge_articles" collection
+    Then the query result for the KnowledgeBase should contain "A Log-Structured Merge-Tree is a data structure designed for efficient writes."
+    And the query result for the KnowledgeBase should not contain "A B-Tree is a self-balancing tree data structure that maintains sorted data."
+
+  Scenario: TissLM generates an augmented prompt using retrieved context
+    Given a user prompt "What is a Log-Structured Merge-Tree?"
+    And a retrieved context from TissDB: "A Log-Structured Merge-Tree (LSM-Tree) is a data structure with performance characteristics that make it attractive for write-heavy workloads."
+
+    When the TissLM augments the prompt with the retrieved context
+    Then the final prompt sent to the language model should be:
+      """
+      context: {A Log-Structured Merge-Tree (LSM-Tree) is a data structure with performance characteristics that make it attractive for write-heavy workloads.} question: {What is a Log-Structured Merge-Tree?}
+      """
+
+  Scenario: Sinew C++ client interaction pattern with TissDB
+    # This scenario simulates the interaction of a C++ application using the Sinew client.
+    # The test is performed at the API level, verifying that the TissDB server
+    # responds correctly to requests that a Sinew client would make.
+    Given a running TissDB instance
+    And a collection named "cpp_app_data" exists
+
+    When a simulated Sinew client creates a document with ID "sinew_doc" and content {"source": "C++ App", "value": 42} in "cpp_app_data"
+    Then the document with ID "sinew_doc" in "cpp_app_data" should have content {"source": "C++ App", "value": 42}
+    When a simulated Sinew client deletes the document with ID "sinew_doc" from "cpp_app_data"
+    Then the document with ID "sinew_doc" in "cpp_app_data" should not exist
+    And I delete the collection "cpp_app_data"

--- a/tests/features/steps/test_integration_steps.py
+++ b/tests/features/steps/test_integration_steps.py
@@ -1,0 +1,84 @@
+import requests
+import json
+import re
+
+BASE_URL = "http://localhost:8080"
+
+def register_steps(runner):
+
+    @runner.step(r'^a TissDB collection named "(.*)" is available for TissLM$')
+    def collection_available_for_tisslm(context, collection_name):
+        # This is effectively the same as creating it if it doesn't exist.
+        response = requests.put(f"{BASE_URL}/{collection_name}")
+        assert response.status_code in [201, 200]
+        context.collection_name = collection_name
+
+    @runner.step(r'^the "(.*)" collection contains a document with ID "(.*)" and content (.*)$')
+    def collection_contains_document(context, collection_name, doc_id, content_str):
+        content = json.loads(content_str)
+        response = requests.put(f"{BASE_URL}/{collection_name}/{doc_id}", json=content)
+        assert response.status_code == 200
+
+    @runner.step(r'^the TissLM receives a user prompt "(.*)"$')
+    def tisslm_receives_prompt(context, prompt):
+        context.user_prompt = prompt
+
+    @runner.step(r'^the TissLM KnowledgeBase formulates a TissQL query "(.*)"$')
+    def knowledgebase_formulates_query(context, query):
+        context.tissql_query = query
+
+    @runner.step(r'^the KnowledgeBase executes the query against the "(.*)" collection$')
+    def knowledgebase_executes_query(context, collection_name):
+        data = {"query": context.tissql_query}
+        response = requests.post(f"{BASE_URL}/{collection_name}/_query", json=data)
+        assert response.status_code == 200
+        context.query_result = response.json()
+
+    @runner.step(r'^the query result for the KnowledgeBase should contain "(.*)"$')
+    def query_result_should_contain(context, expected_text):
+        found = False
+        for item in context.query_result:
+            # Check if any value in the result item's dictionary contains the expected text
+            if any(expected_text in str(val) for val in item.values()):
+                found = True
+                break
+        assert found, f"Expected text '{expected_text}' not found in query result: {context.query_result}"
+
+    @runner.step(r'^the query result for the KnowledgeBase should not contain "(.*)"$')
+    def query_result_should_not_contain(context, unexpected_text):
+        found = False
+        for item in context.query_result:
+            if any(unexpected_text in str(val) for val in item.values()):
+                found = True
+                break
+        assert not found, f"Unexpected text '{unexpected_text}' found in query result: {context.query_result}"
+
+    @runner.step(r'^a user prompt "(.*)"$')
+    def given_user_prompt(context, prompt):
+        context.user_prompt = prompt
+
+    @runner.step(r'^a retrieved context from TissDB: "(.*)"$')
+    def given_retrieved_context(context, retrieved_context):
+        context.retrieved_context = retrieved_context
+
+    @runner.step(r'^the TissLM augments the prompt with the retrieved context$')
+    def tisslm_augments_prompt(context):
+        context.final_prompt = f"context: {{{context.retrieved_context}}} question: {{{context.user_prompt}}}"
+
+    @runner.step(r'the final prompt sent to the language model should be:\s*"""\s*([\s\S]*?)\s*"""')
+    def final_prompt_should_be(context, expected_prompt):
+        # Normalize whitespace and newlines for comparison
+        normalized_actual = re.sub(r'\s+', ' ', context.final_prompt).strip()
+        normalized_expected = re.sub(r'\s+', ' ', expected_prompt).strip()
+        assert normalized_actual == normalized_expected
+
+    @runner.step(r'^a simulated Sinew client creates a document with ID "(.*)" and content (.*) in "(.*)"$')
+    def sinew_creates_document(context, doc_id, content_str, collection_name):
+        content = json.loads(content_str)
+        response = requests.put(f"{BASE_URL}/{collection_name}/{doc_id}", json=content)
+        assert response.status_code == 200
+
+    @runner.step(r'^a simulated Sinew client deletes the document with ID "(.*)" from "(.*)"$')
+    def sinew_deletes_document(context, doc_id, collection_name):
+        response = requests.delete(f"{BASE_URL}/{collection_name}/{doc_id}")
+        assert response.status_code == 204


### PR DESCRIPTION
This commit introduces a new suite of Behavior-Driven Development (BDD) tests to verify the integration between the TissDB, TissLM, and Sinew components, as described in the integration documentation.

The new tests are implemented in a new feature file and a corresponding step definition file:
- `tests/features/integration.feature`: Defines scenarios for the TissLM Retrieval-Augmented Generation (RAG) pipeline and simulated Sinew client interactions.
- `tests/features/steps/test_integration_steps.py`: Implements the Gherkin steps using Python and the `requests` library to interact with the TissDB API.

The BDD test runner (`tests/bdd_runner.py`) has been updated to register and recognize these new test steps.

These tests improve test coverage by validating the key interaction patterns between the system's core components at the API level.