### PR TITLE
feat: Add unit and BDD tests for UPDATE and DELETE queries

### DIFF
--- a/tests/bdd_runner.py
+++ b/tests/bdd_runner.py
@@ -79,6 +79,7 @@ class BDDRunner:
         from tests.features.steps import test_parser_steps
         from tests.features.steps import test_model_integration_steps
         from tests.features.steps import test_integration_steps
+        from tests.features.steps import test_update_delete_steps
         test_kv_cache_steps.register_steps(self)
         test_tokenizer_steps.register_steps(self)
         test_predict_steps.register_steps(self)
@@ -90,6 +91,7 @@ class BDDRunner:
         test_parser_steps.register_steps(self)
         test_model_integration_steps.register_steps(self)
         test_integration_steps.register_steps(self)
+        test_update_delete_steps.register_steps(self)
         print("BDD Runner: All steps registered.")
         sys.stdout.flush()
 

--- a/tests/db/test_update_delete_queries.cpp
+++ b/tests/db/test_update_delete_queries.cpp
@@ -1,0 +1,104 @@
+#include "test_framework.h"
+#include "../../tissdb/storage/lsm_tree.h"
+#include "../../tissdb/query/parser.h"
+#include "../../tissdb/query/executor.h"
+#include "../../tissdb/common/document.h"
+#include <filesystem>
+#include <vector>
+#include <string>
+
+using namespace TissDB;
+
+// Helper function to create a document
+Document create_doc_simple(const std::string& id, const std::string& name, int value) {
+    Document doc;
+    doc.id = id;
+    doc.elements.push_back({"name", name});
+    doc.elements.push_back({"value", (double)value}); // Store as double for consistency
+    return doc;
+}
+
+struct UpdateDeleteTestFixture {
+    const std::string test_dir = "./test_update_delete_data";
+    std::unique_ptr<Storage::LSMTree> storage;
+    std::unique_ptr<Query::Executor> executor;
+
+    UpdateDeleteTestFixture() {
+        if (std::filesystem::exists(test_dir)) {
+            std::filesystem::remove_all(test_dir);
+        }
+        storage = std::make_unique<Storage::LSMTree>(test_dir);
+        executor = std::make_unique<Query::Executor>(*storage);
+
+        // Setup
+        storage->create_collection("test_coll", Schema());
+        storage->put("test_coll", "1", create_doc_simple("1", "doc1", 10));
+        storage->put("test_coll", "2", create_doc_simple("2", "doc2", 20));
+        storage->put("test_coll", "3", create_doc_simple("3", "doc3", 30));
+    }
+
+    ~UpdateDeleteTestFixture() {
+        storage->shutdown();
+        std::filesystem::remove_all(test_dir);
+    }
+};
+
+TEST_CASE(ParserHandlesUpdateQuery) {
+    Query::Parser parser;
+    std::cout << "\nTesting UPDATE query parsing..." << std::endl;
+    Query::AST ast = parser.parse("UPDATE test_coll SET value = 40 WHERE name = 'doc1'");
+
+    ASSERT_EQ(ast.type, Query::AST::StatementType::UPDATE);
+    ASSERT_EQ(ast.collection_name, "test_coll");
+    ASSERT_EQ(ast.update_data.size(), 1);
+    ASSERT_EQ(ast.update_data[0].first, "value");
+    ASSERT_EQ(std::get<double>(ast.update_data[0].second), 40.0);
+    ASSERT_TRUE(ast.where_clause.has_value());
+}
+
+TEST_CASE(ExecutorHandlesUpdateQuery) {
+    UpdateDeleteTestFixture fixture;
+    Query::Parser parser;
+
+    std::cout << "\nTesting UPDATE query execution..." << std::endl;
+    Query::AST ast = parser.parse("UPDATE test_coll SET value = 100 WHERE name = 'doc2'");
+    fixture.executor->execute(ast);
+
+    auto updated_doc_variant = fixture.storage->get("test_coll", "2");
+    ASSERT_TRUE(std::holds_alternative<Document>(updated_doc_variant));
+    Document updated_doc = std::get<Document>(updated_doc_variant);
+
+    bool found = false;
+    for(const auto& el : updated_doc.elements) {
+        if (el.key == "value") {
+            ASSERT_EQ(std::get<double>(el.value), 100.0);
+            found = true;
+        }
+    }
+    ASSERT_TRUE(found);
+}
+
+TEST_CASE(ParserHandlesDeleteQuery) {
+    Query::Parser parser;
+    std::cout << "\nTesting DELETE query parsing..." << std::endl;
+    Query::AST ast = parser.parse("DELETE FROM test_coll WHERE value > 15");
+
+    ASSERT_EQ(ast.type, Query::AST::StatementType::DELETE);
+    ASSERT_EQ(ast.collection_name, "test_coll");
+    ASSERT_TRUE(ast.where_clause.has_value());
+}
+
+TEST_CASE(ExecutorHandlesDeleteQuery) {
+    UpdateDeleteTestFixture fixture;
+    Query::Parser parser;
+
+    std::cout << "\nTesting DELETE query execution..." << std::endl;
+    Query::AST ast = parser.parse("DELETE FROM test_coll WHERE value > 25");
+    fixture.executor->execute(ast);
+
+    auto deleted_doc_variant = fixture.storage->get("test_coll", "3");
+    ASSERT_TRUE(std::holds_alternative<std::monostate>(deleted_doc_variant)); // Should not exist
+
+    auto existing_doc_variant = fixture.storage->get("test_coll", "1");
+    ASSERT_TRUE(std::holds_alternative<Document>(existing_doc_variant)); // Should still exist
+}

--- a/tests/features/steps/test_update_delete_steps.py
+++ b/tests/features/steps/test_update_delete_steps.py
@@ -1,0 +1,43 @@
+import requests
+import json
+import re
+
+BASE_URL = "http://localhost:8080"
+
+def register_steps(runner):
+    # This step is designed to handle the "And I insert the following documents" step
+    # in the background of the update_delete_queries.feature file.
+    @runner.step(r'^And I insert the following documents into "(.*)":$')
+    def insert_documents_from_table(context, collection_name, table_lines):
+        # This is a bit of a hack due to the custom BDD runner.
+        # It seems the runner passes the table as a list of raw string lines.
+        headers_line = table_lines[0]
+        headers = [h.strip() for h in headers_line.strip().strip('|').split('|')]
+
+        for i in range(1, len(table_lines)):
+            row_line = table_lines[i]
+            values = [v.strip() for v in row_line.strip().strip('|').split('|')]
+            doc = dict(zip(headers, values))
+
+            doc_id = doc['id']
+            content = json.loads(doc['content'])
+
+            response = requests.put(f"{BASE_URL}/{collection_name}/{doc_id}", json=content)
+            assert response.status_code == 200, f"Failed to insert doc {doc_id}. Status: {response.status_code}"
+
+    @runner.step(r'^Then the document with ID "(.*)" in "(.*)" should exist$')
+    def document_should_exist(context, doc_id, collection_name):
+        response = requests.get(f"{BASE_URL}/{collection_name}/{doc_id}")
+        assert response.status_code == 200, f"Expected document '{doc_id}' to exist, but it does not (status code: {response.status_code})."
+
+    # The following step is defined in `test_database_steps.py`
+    # When I execute the TissQL query "(.*)" on "(.*)"
+    # We will rely on the runner to have it registered.
+
+    # The following step is also in `test_database_steps.py`
+    # Then the document with ID "(.*)" in "(.*)" should have content (.*)
+    # We will rely on the runner to have it registered.
+
+    # Also from `test_database_steps.py`
+    # Then the document with ID "(.*)" in "(.*)" should not exist
+    # We will rely on the runner to have it registered.

--- a/tests/features/update_delete_queries.feature
+++ b/tests/features/update_delete_queries.feature
@@ -1,0 +1,54 @@
+Feature: TissDB UPDATE and DELETE Query Operations
+
+  Background:
+    Given a running TissDB instance
+    And a collection named "products" exists
+    And I insert the following documents into "products":
+      | id    | content                                            |
+      | prod1 | {"name": "Laptop", "category": "Electronics", "price": 1200} |
+      | prod2 | {"name": "Keyboard", "category": "Electronics", "price": 75}   |
+      | prod3 | {"name": "Mouse", "category": "Electronics", "price": 25}    |
+      | prod4 | {"name": "Desk Chair", "category": "Furniture", "price": 150}  |
+      | prod5 | {"name": "Desk Lamp", "category": "Furniture", "price": 35}    |
+
+  Scenario: Update a single document using a WHERE clause
+    When I execute the TissQL query "UPDATE products SET price = 1250 WHERE name = 'Laptop'" on "products"
+    Then the document with ID "prod1" in "products" should have content {"name": "Laptop", "category": "Electronics", "price": 1250}
+    And the document with ID "prod2" in "products" should have content {"name": "Keyboard", "category": "Electronics", "price": 75}
+
+  Scenario: Update multiple documents using a WHERE clause
+    When I execute the TissQL query "UPDATE products SET price = price + 5 WHERE category = 'Furniture'" on "products"
+    Then the document with ID "prod4" in "products" should have content {"name": "Desk Chair", "category": "Furniture", "price": 155}
+    And the document with ID "prod5" in "products" should have content {"name": "Desk Lamp", "category": "Furniture", "price": 40}
+    And the document with ID "prod1" in "products" should have content {"name": "Laptop", "category": "Electronics", "price": 1200}
+
+  Scenario: Update with a WHERE clause that matches no documents
+    When I execute the TissQL query "UPDATE products SET category = 'Office Supplies' WHERE price > 2000" on "products"
+    Then the document with ID "prod1" in "products" should have content {"name": "Laptop", "category": "Electronics", "price": 1200}
+    And the document with ID "prod2" in "products" should have content {"name": "Keyboard", "category": "Electronics", "price": 75}
+    And the document with ID "prod3" in "products" should have content {"name": "Mouse", "category": "Electronics", "price": 25}
+    And the document with ID "prod4" in "products" should have content {"name": "Desk Chair", "category": "Furniture", "price": 150}
+    And the document with ID "prod5" in "products" should have content {"name": "Desk Lamp", "category": "Furniture", "price": 35}
+
+  Scenario: Delete a single document using a WHERE clause
+    When I execute the TissQL query "DELETE FROM products WHERE name = 'Keyboard'" on "products"
+    Then the document with ID "prod2" in "products" should not exist
+    And the document with ID "prod1" in "products" should exist
+
+  Scenario: Delete multiple documents using a WHERE clause
+    When I execute the TissQL query "DELETE FROM products WHERE category = 'Furniture'" on "products"
+    Then the document with ID "prod4" in "products" should not exist
+    And the document with ID "prod5" in "products" should not exist
+    And the document with ID "prod1" in "products" should exist
+
+  Scenario: Delete with a WHERE clause that matches no documents
+    When I execute the TissQL query "DELETE FROM products WHERE price > 2000" on "products"
+    Then the document with ID "prod1" in "products" should exist
+    And the document with ID "prod2" in "products" should exist
+    And the document with ID "prod3" in "products" should exist
+    And the document with ID "prod4" in "products" should exist
+    And the document with ID "prod5" in "products" should exist
+
+  Scenario Teardown:
+    When I delete the collection "products"
+    Then the collection "products" should not exist


### PR DESCRIPTION
This commit introduces a comprehensive set of tests for the `UPDATE` and `DELETE` functionalities in TissDB.

The changes include:
- A new C++ unit test file (`tests/db/test_update_delete_queries.cpp`) with tests for the query parser and executor for `UPDATE` and `DELETE` statements.
- A new BDD feature file (`tests/features/update_delete_queries.feature`) with scenarios covering various `UPDATE` and `DELETE` operations with `WHERE` clauses.
- A new Python step definition file (`tests/features/steps/test_update_delete_steps.py`) to implement the new BDD scenarios.
- An update to the BDD runner (`tests/bdd_runner.py`) to include the new tests.