### PR TITLE
docs: Add CI/CD pipeline documentation

### DIFF
--- a/quantu_tissu/pipelines/README.md
+++ b/quantu_tissu/pipelines/README.md
@@ -1,0 +1,70 @@
+# QuantaTissu CI/CD Pipelines
+
+This document outlines the continuous integration and deployment (CI/CD) pipelines for the various components of the QuantaTissu project. The goal of these pipelines is to automate the build, test, and deployment processes to ensure a high level of quality and a rapid release cadence.
+
+## 1. TissDB
+
+**TissDB** is a high-performance NoSQL database written in C++. Due to project constraints, the compilation of TissDB is a manual process.
+
+### CI Pipeline
+
+1.  **Linting**: The C++ code is linted for style and formatting issues using `clang-format`.
+2.  **Static Analysis**: A static analysis tool like `cppcheck` is run to identify potential bugs and vulnerabilities.
+3.  **Unit Tests**: The C++ unit tests are executed. These tests are pre-compiled and checked into the repository to avoid a compilation step in the CI pipeline.
+4.  **Integration Tests**: The integration tests, which are also pre-compiled, are run to verify the interaction between different components of TissDB.
+
+### CD Pipeline
+
+1.  **Manual Build**: A project maintainer manually compiles the TissDB binary from the `main` branch. This step is performed outside of the automated CI/CD pipeline.
+2.  **Packaging**: The compiled binary, along with its configuration files, is packaged into a Docker container.
+3.  **Deployment**: The Docker container is pushed to a container registry and deployed to the target environment.
+
+## 2. TissLM
+
+**TissLM** is the core language model of the QuantaTissu project, written in Python.
+
+### CI Pipeline
+
+1.  **Linting**: The Python code is linted using `flake8` and formatted with `black`.
+2.  **Unit Tests**: The Python unit tests are run using `pytest`.
+3.  **BDD Tests**: The Behavior-Driven Development (BDD) tests are executed using `behave`.
+4.  **Dependency Scan**: The `requirements.txt` file is scanned for known vulnerabilities.
+
+### CD Pipeline
+
+1.  **Packaging**: The TissLM package is built and published to a private PyPI repository.
+2.  **Deployment**: The new version of the package is deployed to the production environment.
+
+## 3. Tissu Sinew
+
+**Tissu Sinew** is a C++ connector for TissDB. Similar to TissDB, its compilation is a manual process.
+
+### CI Pipeline
+
+1.  **Linting**: The C++ code is linted for style and formatting issues using `clang-format`.
+2.  **Static Analysis**: A static analysis tool is run to identify potential bugs.
+3.  **Unit Tests**: Pre-compiled unit tests are executed.
+
+### CD Pipeline
+
+1.  **Manual Build**: A project maintainer manually compiles the Tissu Sinew library.
+2.  **Packaging**: The compiled library is packaged for distribution.
+3.  **Publishing**: The package is published to a private repository.
+
+## 4. WebApp (Future)
+
+The **WebApp** will be the primary user interface for interacting with the QuantaTissu agent. It is envisioned as a modern single-page application (SPA).
+
+### CI Pipeline
+
+1.  **Linting**: The JavaScript/TypeScript code is linted using `eslint`.
+2.  **Unit Tests**: Unit tests are run using a framework like `jest`.
+3.  **End-to-End Tests**: End-to-end tests are run using a tool like `Cypress` or `Playwright`.
+4.  **Build**: The application is built for production.
+5.  **Dockerize**: The production build is packaged into a Docker container.
+
+### CD Pipeline
+
+1.  **Push to Registry**: The Docker container is pushed to a container registry.
+2.  **Deploy to Staging**: The new version is deployed to a staging environment for final verification.
+3.  **Deploy to Production**: After successful verification, the new version is deployed to production.


### PR DESCRIPTION
This commit adds a new README.md file to the `quantu_tissu/pipelines` directory. This file describes the continuous integration and deployment (CI/CD) pipelines for the various components of the QuantaTissu project, including `tissdb`, `tisslm`, `sinew`, and a future `webapp`.

The documentation outlines the steps for building, testing, and deploying each component, providing a clear overview of the automation and integration strategy.