### PR TITLE
Feat(parser): Enhance TissLang parser to support single quotes in RUN…

### DIFF
--- a/quanta_tissu/tisslm/tisslang_parser.py
+++ b/quanta_tissu/tisslm/tisslang_parser.py
@@ -23,7 +23,7 @@ class TissLangParser:
         'STEP': re.compile(r'^\s*STEP\s+"([^"]+)"\s*\{\s*$'),
         'SETUP': re.compile(r'^\s*SETUP\s*\{\s*$'),
         'BLOCK_END': re.compile(r'^\s*\}\s*$'),
-        'RUN': re.compile(r'^\s*RUN\s+"([^"]+)"\s*$'),
+        'RUN': re.compile(r'^\s*RUN\s+([\'"])(.*?)\1\s*$'),
         'WRITE': re.compile(r'^\s*WRITE\s+"([^"]+)"\s+<<(\w+)\s*$'),
         'ASSERT': re.compile(r'^\s*ASSERT\s+(.+?)\s*$'),
         'READ': re.compile(r'^\s*READ\s+"([^"]+)"\s+AS\s+([a-zA-Z_][a-zA-Z0-9_]*)\s*$'),
@@ -137,7 +137,7 @@ class TissLangParser:
 
         run_match = self._PATTERNS['RUN'].match(line)
         if run_match:
-            self._current_block.append({'type': 'RUN', 'command': run_match.group(1)})
+            self._current_block.append({'type': 'RUN', 'command': run_match.group(2)})
             return
 
         assert_match = self._PATTERNS['ASSERT'].match(line)

--- a/tests/test_tisslang_parser.py
+++ b/tests/test_tisslang_parser.py
@@ -115,5 +115,21 @@ class TestTissLangParser(unittest.TestCase):
         with self.assertRaises(TissLangParserError):
             parser.parse(script)
 
+    def test_parse_run_with_single_quotes_and_inner_quotes(self):
+        parser = TissLangParser()
+        script = '''
+        STEP "Run a command with quotes" {
+            RUN 'echo "Hello, quoted world!"'
+        }
+        '''
+        expected_ast = [{
+            'type': 'STEP',
+            'description': 'Run a command with quotes',
+            'commands': [{'type': 'RUN', 'command': 'echo "Hello, quoted world!"'}]
+        }]
+        ast = parser.parse(script)
+        self.assertEqual(ast, expected_ast)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
… command

This commit enhances the TissLang parser to support both single and double quotes for the `RUN` command's arguments.

The previous implementation only allowed double quotes, which made it impossible to run commands that contained double-quoted strings as arguments.

The regex for the `RUN` command in `quanta_tissu/tisslm/tisslang_parser.py` has been updated to use a backreference, allowing it to match either single or double quotes as the outer delimiter. The handler logic was updated to use the correct capture group from the new regex.

A new unit test was added to `tests/test_tisslang_parser.py` to verify the new functionality, ensuring that commands like `RUN 'echo "Hello"'` are parsed correctly.