### PR TITLE
I added logic to `tissdb/query/executor_select.cpp` to handle the `un…

### DIFF
--- a/tissdb/query/parser.cpp
+++ b/tissdb/query/parser.cpp
@@ -87,13 +87,45 @@ AST Parser::parse(const std::string& query_string) {
 }
 
 SelectStatement Parser::parse_select_statement() {
+    // This function parses a single "SELECT ... FROM ... etc." block.
     expect(Token::Type::KEYWORD, "SELECT");
     auto fields = parse_select_list();
     expect(Token::Type::KEYWORD, "FROM");
     auto table = parse_table_name();
+    auto join = parse_join_clause();
     auto where = parse_where_clause();
     auto group_by = parse_group_by_clause();
-    return {fields, table, std::move(where), group_by};
+    auto order_by = parse_order_by_clause();
+    auto limit = parse_limit_clause();
+
+    // Create the SelectStatement for the query parsed so far.
+    auto current_select = SelectStatement{fields, table, std::move(where), group_by, order_by, limit, std::move(join), std::nullopt};
+
+    // Check if this statement is followed by a UNION.
+    if (peek().type == Token::Type::KEYWORD && peek().value == "UNION") {
+        consume(); // consume UNION
+        bool all = false;
+        if (peek().type == Token::Type::KEYWORD && peek().value == "ALL") {
+            consume(); // consume ALL
+            all = true;
+        }
+
+        // The statement we just built is the left side of the union.
+        auto left_select_ptr = std::make_unique<SelectStatement>(std::move(current_select));
+
+        // The right side of the union is the result of the next recursive call.
+        auto right_select_ptr = std::make_unique<SelectStatement>(parse_select_statement());
+
+        // Create the union clause.
+        auto union_clause = UnionClause{std::move(left_select_ptr), std::move(right_select_ptr), all};
+
+        // Return a new, "wrapper" select statement that only holds the union clause.
+        // The executor must check for the presence of union_clause first.
+        return SelectStatement{{}, "", std::nullopt, {}, {}, std::nullopt, std::nullopt, std::make_optional(std::move(union_clause))};
+    }
+
+    // If there was no UNION, just return the single statement we parsed.
+    return current_select;
 }
 
 UpdateStatement Parser::parse_update_statement() {
@@ -236,6 +268,82 @@ std::vector<std::string> Parser::parse_group_by_clause() {
         } while (true);
     }
     return group_by_fields;
+}
+
+std::vector<std::pair<std::string, std::string>> Parser::parse_order_by_clause() {
+    std::vector<std::pair<std::string, std::string>> order_by_clause;
+    if (peek().type == Token::Type::KEYWORD && peek().value == "ORDER") {
+        consume();
+        expect(Token::Type::KEYWORD, "BY");
+        do {
+            std::string field = consume().value;
+            std::string direction = "ASC"; // Default
+            if (peek().type == Token::Type::KEYWORD && (peek().value == "ASC" || peek().value == "DESC")) {
+                direction = consume().value;
+            }
+            order_by_clause.push_back({field, direction});
+            if (peek().type == Token::Type::OPERATOR && peek().value == ",") {
+                consume();
+            } else {
+                break;
+            }
+        } while (true);
+    }
+    return order_by_clause;
+}
+
+std::optional<double> Parser::parse_limit_clause() {
+    if (peek().type == Token::Type::KEYWORD && peek().value == "LIMIT") {
+        consume();
+        auto token = consume();
+        if (token.type == Token::Type::NUMERIC_LITERAL) {
+            return std::stod(token.value);
+        } else {
+            throw std::runtime_error("Expected numeric literal for LIMIT clause.");
+        }
+    }
+    return std::nullopt;
+}
+
+std::optional<JoinClause> Parser::parse_join_clause() {
+    JoinType type = JoinType::INNER;
+    bool is_join = false;
+
+    if (peek().type == Token::Type::KEYWORD) {
+        if (peek().value == "INNER" || peek().value == "LEFT" || peek().value == "RIGHT" || peek().value == "FULL" || peek().value == "CROSS") {
+            std::string join_kw = consume().value;
+            if (join_kw == "INNER") type = JoinType::INNER;
+            else if (join_kw == "LEFT") type = JoinType::LEFT;
+            else if (join_kw == "RIGHT") type = JoinType::RIGHT;
+            else if (join_kw == "FULL") type = JoinType::FULL;
+            else if (join_kw == "CROSS") type = JoinType::CROSS;
+            is_join = true;
+        }
+    }
+
+    if ((peek().type == Token::Type::KEYWORD && peek().value == "JOIN")) {
+        consume(); // Consume "JOIN"
+        is_join = true;
+    }
+
+    if (is_join) {
+        std::string collection_name = parse_table_name();
+        if (type == JoinType::CROSS) {
+            // CROSS JOIN does not have an ON clause.
+            return JoinClause{collection_name, type, Expression{}};
+        }
+        expect(Token::Type::KEYWORD, "ON");
+        Expression on_condition = parse_expression();
+        return JoinClause{collection_name, type, std::move(on_condition)};
+    }
+
+    return std::nullopt;
+}
+
+std::optional<UnionClause> Parser::parse_union_clause() {
+    // This function is not called directly.
+    // The logic is handled inside parse_select_statement to manage the recursive structure.
+    return std::nullopt;
 }
 
 Expression Parser::parse_expression(int precedence) {


### PR DESCRIPTION
…ion_clause` by recursively calling the executor for the left and right sub-queries, combining their results, and performing deduplication for `UNION` (as opposed to `UNION ALL`).