### PR TITLE
Fix C++ build and compilation errors in tissdb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ dist/
 # C++
 *.out
 test_sinew_app
+tissdb/tissdb

--- a/tissdb/Makefile
+++ b/tissdb/Makefile
@@ -25,10 +25,10 @@ SRCS = main.cpp \
        storage/collection.cpp \
        storage/indexer.cpp \
        storage/lsm_tree.cpp \
+       storage/memtable.cpp \
        storage/transaction_manager.cpp \
        storage/native_b_tree.cpp \
        storage/sstable.cpp \
-       storage/transaction_manager.cpp \
        storage/wal.cpp \
        ../quanta_tissu/tissu_sinew.cpp \
        ../tests/db/http_client.cpp

--- a/tissdb/query/executor.cpp
+++ b/tissdb/query/executor.cpp
@@ -12,13 +12,13 @@ Executor::Executor(Storage::LSMTree& storage) : storage_engine(storage) {}
 
 QueryResult Executor::execute(AST ast) {
     if (auto* select_stmt = std::get_if<SelectStatement>(&ast)) {
-        return execute_select_statement(storage_engine, std::move(*select_stmt));
+        return execute_select_statement(storage_engine, *select_stmt);
     } else if (auto* insert_stmt = std::get_if<InsertStatement>(&ast)) {
-        return execute_insert_statement(storage_engine, std::move(*insert_stmt));
+        return execute_insert_statement(storage_engine, *insert_stmt);
     } else if (auto* update_stmt = std::get_if<UpdateStatement>(&ast)) {
-        return execute_update_statement(storage_engine, std::move(*update_stmt));
+        return execute_update_statement(storage_engine, *update_stmt);
     } else if (auto* delete_stmt = std::get_if<DeleteStatement>(&ast)) {
-        return execute_delete_statement(storage_engine, std::move(*delete_stmt));
+        return execute_delete_statement(storage_engine, *delete_stmt);
     }
     // Note: The original executor had a recursive call for UNION.
     // This simplified dispatcher doesn't handle that directly.

--- a/tissdb/query/executor_select.h
+++ b/tissdb/query/executor_select.h
@@ -7,7 +7,7 @@
 namespace TissDB {
 namespace Query {
 
-QueryResult execute_select_statement(Storage::LSMTree& storage_engine, SelectStatement select_stmt);
+QueryResult execute_select_statement(Storage::LSMTree& storage_engine, const SelectStatement& select_stmt);
 
 } // namespace Query
 } // namespace TissDB


### PR DESCRIPTION
This commit resolves several issues that prevented the `tissdb` C++ application from compiling successfully.

- The function signature for `execute_select_statement` in `query/executor_select.h` was updated to use a `const` reference, resolving an ambiguous function call error during compilation.
- The `Makefile` was corrected by:
    - Removing a duplicate entry for `storage/transaction_manager.cpp`.
    - Adding the missing `storage/memtable.cpp` source file to the build, which fixed an undefined reference linker error.
- Unnecessary `std::move` calls were removed from `query/executor.cpp`. These calls were causing the compiler to resolve to incorrect function overloads, leading to linker errors.
- The `.gitignore` file was updated to exclude the `tissdb/tissdb` executable, preventing issues with large build artifacts in the repository.