### PR TITLE
Fix ImportError for vocab and other BDD test issues

### DIFF
--- a/docs/test.md
+++ b/docs/test.md
@@ -60,7 +60,7 @@ As a user, I want the model to handle words that are not in its vocabulary.
 **Given** a QuantaTissu model with a fixed vocabulary
 **And** a sentence "this is a foobar test"
 **When** I tokenize the sentence
-**Then** the token "foobar" should be mapped to the `<unk>` token ID.
+**Then** the token "foobar" should be mapped to the "<unk>" token ID
 
 ### 2.3. Generating Text with Knowledge Base
 

--- a/quanta_tissu/tisslm/config.py
+++ b/quanta_tissu/tisslm/config.py
@@ -44,7 +44,7 @@ model_config = {
     "n_layers": 2,       # The number of Transformer blocks.
     "num_heads": 4,      # The number of attention heads in the Multi-Head Attention layers.
     "d_ff": 128,         # The dimensionality of the inner layer of the Feed-Forward Networks.
-    "vocab_size": None,  # Will be set dynamically in run_training.py
+    "vocab_size": 512,  # Will be set dynamically in run_training.py
     "layer_norm_eps": 1e-6, # Epsilon for Layer Normalization to prevent division by zero.
     # Max length for positional encodings, tied to tokenizer's max length.
     "positional_encoding_max_len": tokenizer_config["max_len"],

--- a/quanta_tissu/tisslm/run_tiss.py
+++ b/quanta_tissu/tisslm/run_tiss.py
@@ -8,7 +8,7 @@ import sys
 import os
 sys.path.append(os.getcwd())
 
-from quanta_tissu.scripts.tisslang_parser import TissLangParser, TissLangParserError
+from quanta_tissu.tisslm.tisslang_parser import TissLangParser, TissLangParserError
 from quanta_tissu.tisslm.execution_engine import ExecutionEngine, ToolRegistry
 from quanta_tissu.tisslm.tools import run_command, write_file, read_file, assert_condition, TissCommandError
 

--- a/tests/disabled_test_kv_cache.py
+++ b/tests/disabled_test_kv_cache.py
@@ -8,7 +8,7 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from quanta_tissu.tisslm.model import QuantaTissu
 from quanta_tissu.tisslm.config import model_config
-from quanta_tissu.tisslm.tokenizer import Tokenizer, vocab
+from quanta_tissu.tisslm.tokenizer import Tokenizer
 
 class TestKVCache(unittest.TestCase):
 
@@ -16,7 +16,7 @@ class TestKVCache(unittest.TestCase):
         """Set up a model and tokenizer for the tests."""
         np.random.seed(42)
         self.model = QuantaTissu(model_config)
-        self.tokenizer = Tokenizer(vocab)
+        self.tokenizer = Tokenizer()
 
     def test_kv_cache_correctness(self):
         """

--- a/tests/features/steps/test_generate_steps.py
+++ b/tests/features/steps/test_generate_steps.py
@@ -1,14 +1,14 @@
 import numpy as np
 from quanta_tissu.tisslm.model import QuantaTissu
 from quanta_tissu.tisslm.config import model_config
-from quanta_tissu.tisslm.tokenizer import Tokenizer, vocab
+from quanta_tissu.tisslm.tokenizer import Tokenizer
 
 def register_steps(runner):
     @runner.step(r'^Given a model and tokenizer$')
     def context(context):
         np.random.seed(42)
         model = QuantaTissu(model_config)
-        tokenizer = Tokenizer(vocab)
+        tokenizer = Tokenizer()
         context['model'] = model
         context['tokenizer'] = tokenizer
         

--- a/tests/features/steps/test_knowledge_base_steps.py
+++ b/tests/features/steps/test_knowledge_base_steps.py
@@ -1,7 +1,7 @@
 import numpy as np
 from quanta_tissu.tisslm.model import QuantaTissu
 from quanta_tissu.tisslm.config import model_config
-from quanta_tissu.tisslm.tokenizer import Tokenizer, vocab
+from quanta_tissu.tisslm.tokenizer import Tokenizer
 from quanta_tissu.tisslm.knowledge_base import KnowledgeBase
 
 def register_steps(runner):
@@ -9,7 +9,7 @@ def register_steps(runner):
     def knowledge_base_context(context):
         np.random.seed(42)
         model = QuantaTissu(model_config)
-        tokenizer = Tokenizer(vocab)
+        tokenizer = Tokenizer()
         context['model'] = model # Store model for other steps
         context['tokenizer'] = tokenizer # Store tokenizer for other steps
         context['knowledge_base'] = KnowledgeBase(model.embeddings, tokenizer)

--- a/tests/features/steps/test_kv_cache_steps.py
+++ b/tests/features/steps/test_kv_cache_steps.py
@@ -7,14 +7,14 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(
 
 from quanta_tissu.tisslm.model import QuantaTissu
 from quanta_tissu.tisslm.config import model_config
-from quanta_tissu.tisslm.tokenizer import Tokenizer, vocab
+from quanta_tissu.tisslm.tokenizer import Tokenizer
 
 def register_steps(runner):
     @runner.step(r'^Given a model and tokenizer$')
     def context(context):
         np.random.seed(42)
         model = QuantaTissu(model_config)
-        tokenizer = Tokenizer(vocab)
+        tokenizer = Tokenizer()
         context['model'] = model
         context['tokenizer'] = tokenizer
 

--- a/tests/features/steps/test_parser_steps.py
+++ b/tests/features/steps/test_parser_steps.py
@@ -1,5 +1,5 @@
 import json
-from quanta_tissu.scripts.tisslang_parser import TissLangParser, TissLangParserError
+from quanta_tissu.tisslm.tisslang_parser import TissLangParser, TissLangParserError
 
 def register_steps(runner):
     @runner.step(r'Given a TissLang script:\s*"""\s*([\s\S]*?)"""')

--- a/tests/features/steps/test_predict_steps.py
+++ b/tests/features/steps/test_predict_steps.py
@@ -1,14 +1,14 @@
 import numpy as np
 from quanta_tissu.tisslm.model import QuantaTissu
 from quanta_tissu.tisslm.config import model_config
-from quanta_tissu.tisslm.tokenizer import Tokenizer, vocab
+from quanta_tissu.tisslm.tokenizer import Tokenizer
 
 def register_steps(runner):
     @runner.step(r'^Given a model and tokenizer$')
     def context(context):
         np.random.seed(42)
         model = QuantaTissu(model_config)
-        tokenizer = Tokenizer(vocab)
+        tokenizer = Tokenizer()
         context['model'] = model
         context['tokenizer'] = tokenizer
 
@@ -23,5 +23,5 @@ def register_steps(runner):
     def check_next_token(context):
         assert isinstance(context['next_token_id'], int)
         assert context['next_token_id'] >= 0
-        assert context['next_token_id'] < len(vocab)
+        assert context['next_token_id'] < context['tokenizer'].get_vocab_size()
         return "Test passed!"

--- a/tests/test_bdd.py
+++ b/tests/test_bdd.py
@@ -95,7 +95,7 @@ def run_bdd_scenarios(features):
 
 @step(r'Given a trained QuantaTissu model')
 def given_a_model(context):
-    context['model'] = QuantaTissu(model_config)
+    context['model'] = QuantaTissu(model_config, use_db=False)
 
 @step(r'And a prompt "(.*)"')
 def and_a_prompt(context, prompt):
@@ -151,7 +151,7 @@ def then_return_sequence_of_token_ids(context, num_tokens):
 
 @step(r'Given a QuantaTissu model with a fixed vocabulary')
 def given_a_model_with_fixed_vocab(context):
-    context['model'] = QuantaTissu(model_config)
+    context['model'] = QuantaTissu(model_config, use_db=False)
 
 @step(r'And a sentence "(.*)"')
 def and_a_sentence(context, sentence):


### PR DESCRIPTION
This commit addresses a fatal ImportError for `vocab` from `quanta_tissu.tisslm.tokenizer`.

The fix involves several changes:
- Removed the direct import of `vocab` from `tokenizer.py` in all affected files.
- The `Tokenizer` class is now instantiated without arguments, and the vocabulary size is retrieved using the `get_vocab_size()` method.
- Corrected another `ImportError` for `tisslang_parser` that was introduced during development.
- Set a default `vocab_size` in the model configuration to prevent errors when running tests without a trained model.
- Disabled the database connection in BDD tests that do not require it, allowing them to run without a database server.
- Fixed a minor issue in the BDD feature file to allow a previously skipped test to run.