### PR TITLE
refactor: Move importer/exporter tool to quanta_tissu

### DIFF
--- a/quanta_tissu/integrations/importer_exporter/README.md
+++ b/quanta_tissu/integrations/importer_exporter/README.md
@@ -1,0 +1,84 @@
+# TissDB Importer/Exporter
+
+This tool allows you to import and export data from a TissDB instance using CSV or XML file formats.
+
+## Features
+
+- Export data from a TissDB collection to a CSV or XML file.
+- Import data from a CSV or XML file into a TissDB collection.
+- Automatic type conversion for imported data (string, integer, float, boolean).
+
+## Prerequisites
+
+Before using this tool, you need to have Python 3 and the `requests` library installed.
+
+You can install the `requests` library using pip:
+```bash
+pip install requests
+```
+
+You also need a running instance of TissDB that is accessible from where you are running the script.
+
+## Usage
+
+The tool is operated from the command line. The basic syntax is:
+
+```bash
+python3 importer_exporter.py [action] [format] [collection] [filepath] [options]
+```
+
+### Arguments
+
+- `action`: The action to perform. Must be either `import` or `export`.
+- `format`: The data format to use. Must be either `csv` or `xml`.
+- `collection`: The name of the TissDB collection to interact with.
+- `filepath`: The path to the file to be used for importing or exporting.
+- `--base-url`: (Optional) The base URL of the TissDB server. Defaults to `http://localhost:8080`.
+
+### Examples
+
+#### Exporting to CSV
+To export all documents from the `users` collection to a file named `users.csv`:
+```bash
+python3 importer_exporter.py export csv users users.csv
+```
+
+#### Importing from CSV
+To import documents from `users.csv` into the `users` collection:
+```bash
+python3 importer_exporter.py import csv users users.csv
+```
+
+#### Exporting to XML
+To export all documents from the `products` collection to a file named `products.xml`:
+```bash
+python3 importer_exporter.py export xml products products.xml
+```
+
+#### Importing from XML
+To import documents from `products.xml` into the `products` collection:
+```bash
+python3 importer_exporter.py import xml products products.xml
+```
+
+#### Using a different TissDB instance
+To connect to a TissDB server running on a different host or port, use the `--base-url` option:
+```bash
+python3 importer_exporter.py export csv users users.csv --base-url http://tissdb.example.com:8000
+```
+
+## Sample Data
+
+This directory includes `sample_data.csv` and `sample_data.xml` files that you can use to test the tool.
+
+**To test the import:**
+```bash
+# Assuming a running TissDB instance and an empty 'users' collection
+python3 importer_exporter.py import csv users sample_data.csv
+```
+
+**To test the export:**
+```bash
+# This will create a new file named 'export_test.csv' with the data from the 'users' collection
+python3 importer_exporter.py export csv users export_test.csv
+```

--- a/quanta_tissu/integrations/importer_exporter/importer_exporter.py
+++ b/quanta_tissu/integrations/importer_exporter/importer_exporter.py
@@ -1,0 +1,235 @@
+import requests
+import json
+import csv
+import xml.etree.ElementTree as ET
+import argparse
+
+# ==============================================================================
+# TissDB API Client
+# ==============================================================================
+
+class TissDBAPIClient:
+    """
+    A client for the TissDB HTTP API.
+    """
+    def __init__(self, base_url="http://localhost:8080"):
+        """
+        Initializes the client with the base URL of the TissDB server.
+        """
+        self.base_url = base_url.rstrip('/')
+
+    def get_all_documents(self, collection_name: str) -> list[dict]:
+        """
+        Retrieves all documents from a specified collection.
+        """
+        url = f"{self.base_url}/{collection_name}/_query"
+        payload = {"query": "SELECT *"}
+        response = requests.post(url, json=payload)
+        response.raise_for_status()
+        return response.json()
+
+    def insert_document(self, collection_name: str, document: dict) -> dict:
+        """
+        Inserts a single document into a specified collection.
+        """
+        url = f"{self.base_url}/{collection_name}"
+        response = requests.post(url, json=document)
+        response.raise_for_status()
+        return response.json()
+
+# ==============================================================================
+# Helper Functions
+# ==============================================================================
+
+def _convert_value(value: str):
+    """
+    Tries to convert a string value to a more specific type (int, float, bool).
+    """
+    if not value:
+        return None
+
+    # Try converting to int
+    try:
+        return int(value)
+    except ValueError:
+        pass
+
+    # Try converting to float
+    try:
+        return float(value)
+    except ValueError:
+        pass
+
+    # Check for boolean
+    if value.lower() == 'true':
+        return True
+    if value.lower() == 'false':
+        return False
+
+    return value
+
+# ==============================================================================
+# Core Import/Export Logic
+# ==============================================================================
+
+def export_to_csv(collection_name: str, file_path: str, base_url: str):
+    """
+    Exports all documents from a TissDB collection to a CSV file.
+    """
+    print(f"Starting export of collection '{collection_name}' to '{file_path}'...")
+    try:
+        client = TissDBAPIClient(base_url)
+        documents = client.get_all_documents(collection_name)
+
+        if not documents:
+            print("No documents found in the collection. Nothing to export.")
+            return
+
+        header = set()
+        for doc in documents:
+            header.update(doc.keys())
+
+        sorted_header = sorted(list(header))
+
+        with open(file_path, 'w', newline='', encoding='utf-8') as csvfile:
+            writer = csv.DictWriter(csvfile, fieldnames=sorted_header)
+            writer.writeheader()
+            writer.writerows(documents)
+
+        print(f"Successfully exported {len(documents)} documents to '{file_path}'.")
+
+    except requests.exceptions.RequestException as e:
+        print(f"Error connecting to TissDB: {e}")
+    except IOError as e:
+        print(f"Error writing to file '{file_path}': {e}")
+    except Exception as e:
+        print(f"An unexpected error occurred: {e}")
+
+def import_from_csv(collection_name: str, file_path: str, base_url: str):
+    """
+    Imports documents from a CSV file into a TissDB collection.
+    """
+    print(f"Starting import from '{file_path}' to collection '{collection_name}'...")
+    try:
+        client = TissDBAPIClient(base_url)
+        count = 0
+        with open(file_path, 'r', encoding='utf-8') as csvfile:
+            reader = csv.DictReader(csvfile)
+            for row in reader:
+                document = {key: _convert_value(value) for key, value in row.items()}
+                client.insert_document(collection_name, document)
+                count += 1
+                if count % 100 == 0:
+                    print(f"Imported {count} documents...")
+
+        print(f"Successfully imported {count} documents from '{file_path}'.")
+
+    except FileNotFoundError:
+        print(f"Error: The file '{file_path}' was not found.")
+    except requests.exceptions.RequestException as e:
+        print(f"Error connecting to TissDB: {e}")
+    except IOError as e:
+        print(f"Error reading file '{file_path}': {e}")
+    except Exception as e:
+        print(f"An unexpected error occurred: {e}")
+
+def export_to_xml(collection_name: str, file_path: str, base_url: str):
+    """
+    Exports all documents from a TissDB collection to an XML file.
+    """
+    print(f"Starting export of collection '{collection_name}' to '{file_path}'...")
+    try:
+        client = TissDBAPIClient(base_url)
+        documents = client.get_all_documents(collection_name)
+
+        if not documents:
+            print("No documents found in the collection. Nothing to export.")
+            return
+
+        root = ET.Element("data")
+        for doc in documents:
+            item = ET.SubElement(root, "item")
+            for key, value in doc.items():
+                child = ET.SubElement(item, str(key))
+                child.text = str(value)
+
+        ET.indent(root, space="\t")
+
+        tree = ET.ElementTree(root)
+        tree.write(file_path, encoding='utf-8', xml_declaration=True)
+
+        print(f"Successfully exported {len(documents)} documents to '{file_path}'.")
+
+    except requests.exceptions.RequestException as e:
+        print(f"Error connecting to TissDB: {e}")
+    except IOError as e:
+        print(f"Error writing to file '{file_path}': {e}")
+    except Exception as e:
+        print(f"An unexpected error occurred: {e}")
+
+def import_from_xml(collection_name: str, file_path: str, base_url: str):
+    """
+    Imports documents from an XML file into a TissDB collection.
+    """
+    print(f"Starting import from '{file_path}' to collection '{collection_name}'...")
+    try:
+        client = TissDBAPIClient(base_url)
+        count = 0
+
+        tree = ET.parse(file_path)
+        root = tree.getroot()
+
+        for item in root.findall('item'):
+            document = {}
+            for child in item:
+                document[child.tag] = _convert_value(child.text)
+
+            client.insert_document(collection_name, document)
+            count += 1
+            if count % 100 == 0:
+                print(f"Imported {count} documents...")
+
+        print(f"Successfully imported {count} documents from '{file_path}'.")
+
+    except FileNotFoundError:
+        print(f"Error: The file '{file_path}' was not found.")
+    except ET.ParseError as e:
+        print(f"Error parsing XML file '{file_path}': {e}")
+    except requests.exceptions.RequestException as e:
+        print(f"Error connecting to TissDB: {e}")
+    except IOError as e:
+        print(f"Error reading file '{file_path}': {e}")
+    except Exception as e:
+        print(f"An unexpected error occurred: {e}")
+
+# ==============================================================================
+# Command-Line Interface
+# ==============================================================================
+
+def main():
+    """
+    Main function to run the command-line interface.
+    """
+    parser = argparse.ArgumentParser(description="TissDB Importer/Exporter Tool")
+
+    parser.add_argument("action", choices=['import', 'export'], help="The action to perform: 'import' or 'export'.")
+    parser.add_argument("format", choices=['csv', 'xml'], help="The data format to use: 'csv' or 'xml'.")
+    parser.add_argument("collection", help="The name of the TissDB collection.")
+    parser.add_argument("filepath", help="The path to the input/output file.")
+    parser.add_argument("--base-url", default="http://localhost:8080", help="The base URL of the TissDB server.")
+
+    args = parser.parse_args()
+
+    if args.action == 'import':
+        if args.format == 'csv':
+            import_from_csv(args.collection, args.filepath, args.base_url)
+        elif args.format == 'xml':
+            import_from_xml(args.collection, args.filepath, args.base_url)
+    elif args.action == 'export':
+        if args.format == 'csv':
+            export_to_csv(args.collection, args.filepath, args.base_url)
+        elif args.format == 'xml':
+            export_to_xml(args.collection, args.filepath, args.base_url)
+
+if __name__ == "__main__":
+    main()

--- a/quanta_tissu/integrations/importer_exporter/sample_data.csv
+++ b/quanta_tissu/integrations/importer_exporter/sample_data.csv
@@ -1,0 +1,6 @@
+id,name,age,city,is_member
+1,"Alice",30,"New York",true
+2,"Bob",25,"Los Angeles",false
+3,"Charlie",35,"Chicago",true
+4,"David",40,"Houston",
+5,"Eve",28,"Phoenix",true

--- a/quanta_tissu/integrations/importer_exporter/sample_data.xml
+++ b/quanta_tissu/integrations/importer_exporter/sample_data.xml
@@ -1,0 +1,38 @@
+<?xml version='1.0' encoding='utf-8'?>
+<data>
+	<item>
+		<id>1</id>
+		<name>Alice</name>
+		<age>30</age>
+		<city>New York</city>
+		<is_member>True</is_member>
+	</item>
+	<item>
+		<id>2</id>
+		<name>Bob</name>
+		<age>25</age>
+		<city>Los Angeles</city>
+		<is_member>False</is_member>
+	</item>
+	<item>
+		<id>3</id>
+		<name>Charlie</name>
+		<age>35</age>
+		<city>Chicago</city>
+		<is_member>True</is_member>
+	</item>
+	<item>
+		<id>4</id>
+		<name>David</name>
+		<age>40</age>
+		<city>Houston</city>
+		<is_member>None</is_member>
+	</item>
+	<item>
+		<id>5</id>
+		<name>Eve</name>
+		<age>28</age>
+		<city>Phoenix</city>
+		<is_member>True</is_member>
+	</item>
+</data>


### PR DESCRIPTION
This change refactors the directory structure to move the recently added CSV/XML importer/exporter tool.

The tool's directory has been moved from:
`integrations/importer_exporter`

to:
`quanta_tissu/integrations/importer_exporter`

This places the tool within the `quanta_tissu` project, which is a more logical location for this integration.