### PR TITLE
feat: Add SQL import and export functionality

### DIFF
--- a/quanta_tissu/integrations/importer_exporter/README.md
+++ b/quanta_tissu/integrations/importer_exporter/README.md
@@ -4,8 +4,8 @@ This tool allows you to import and export data from a TissDB instance using CSV 
 
 ## Features
 
-- Export data from a TissDB collection to a CSV or XML file.
-- Import data from a CSV or XML file into a TissDB collection.
+- Export data from a TissDB collection to a CSV, XML, or SQL file.
+- Import data from a CSV, XML, or SQL file into a TissDB collection.
 - Automatic type conversion for imported data (string, integer, float, boolean).
 
 ## Prerequisites
@@ -30,7 +30,7 @@ python3 importer_exporter.py [action] [format] [collection] [filepath] [options]
 ### Arguments
 
 - `action`: The action to perform. Must be either `import` or `export`.
-- `format`: The data format to use. Must be either `csv` or `xml`.
+- `format`: The data format to use. Must be either `csv`, `xml`, or `sql`.
 - `collection`: The name of the TissDB collection to interact with.
 - `filepath`: The path to the file to be used for importing or exporting.
 - `--base-url`: (Optional) The base URL of the TissDB server. Defaults to `http://localhost:8080`.
@@ -61,6 +61,18 @@ To import documents from `products.xml` into the `products` collection:
 python3 importer_exporter.py import xml products products.xml
 ```
 
+#### Exporting to SQL
+To export all documents from the `users` collection to a file named `users.sql`:
+```bash
+python3 importer_exporter.py export sql users users.sql
+```
+
+#### Importing from SQL
+To import documents from `users.sql` into the `users` collection:
+```bash
+python3 importer_exporter.py import sql users users.sql
+```
+
 #### Using a different TissDB instance
 To connect to a TissDB server running on a different host or port, use the `--base-url` option:
 ```bash
@@ -69,7 +81,7 @@ python3 importer_exporter.py export csv users users.csv --base-url http://tissdb
 
 ## Sample Data
 
-This directory includes `sample_data.csv` and `sample_data.xml` files that you can use to test the tool.
+This directory includes `sample_data.csv`, `sample_data.xml`, and `sample_data.sql` files that you can use to test the tool.
 
 **To test the import:**
 ```bash
@@ -82,3 +94,45 @@ python3 importer_exporter.py import csv users sample_data.csv
 # This will create a new file named 'export_test.csv' with the data from the 'users' collection
 python3 importer_exporter.py export csv users export_test.csv
 ```
+
+## Implementation Details and Challenges
+
+Implementing the SQL import and export functionality involved several challenges. This section provides an overview of the approach taken and the key decisions made during development.
+
+### SQL Export (`export_to_sql`)
+
+The export process generates a `.sql` file containing a `CREATE TABLE` statement and a series of `INSERT` statements based on the documents in a TissDB collection.
+
+**Challenge: Data Type Inference**
+
+TissDB stores data in a JSON-like format, where data types are dynamic (e.g., `string`, `integer`, `float`, `boolean`). SQL, on the other hand, requires a fixed schema with strongly typed columns (`TEXT`, `INTEGER`, `REAL`, `BOOLEAN`).
+
+To address this, the `export_to_sql` function implements a type inference mechanism:
+1.  It first scans all documents to gather a set of all unique keys, which become the columns of the SQL table.
+2.  For each column, it then iterates through all documents to inspect the type of every value.
+3.  A type hierarchy is used to determine the most appropriate SQL type for the column:
+    - If any value is a string, or if there's a mix of incompatible types (e.g., integers and booleans), the column type defaults to `TEXT` for maximum compatibility.
+    - If a column contains only numbers, it becomes `REAL` if any of them are floats, or `INTEGER` if all are integers.
+    - A column with only boolean values is typed as `BOOLEAN`.
+
+This ensures that the generated `CREATE TABLE` statement is as accurate as possible while preventing data loss.
+
+### SQL Import (`import_from_sql`)
+
+The import process reads a `.sql` file and inserts the data into a TissDB collection.
+
+**Challenge: SQL Parsing**
+
+SQL is a complex language, and writing a robust parser from scratch is a significant undertaking. A simple regex-based parser would be too brittle to handle the variations in SQL syntax.
+
+To solve this, the implementation uses the `sqlparse` Python library. This library is excellent at tokenizing SQL statements and identifying their structure without being a full-fledged semantic parser. The `import_from_sql` function uses it to:
+1.  Split the content of the `.sql` file into individual statements.
+2.  Identify `INSERT` statements.
+3.  For each `INSERT` statement, it extracts the list of column names and the corresponding values.
+4.  It then reconstructs a JSON document from the columns and values and inserts it into the specified TissDB collection.
+
+The script reuses the `_convert_value` helper function to automatically convert the string values from the SQL file into appropriate Python types (integer, float, boolean, or string).
+
+### General Challenge: Database Dependency
+
+This tool requires a running instance of the TissDB server to function. During development and testing, this can be a hurdle if the server is not available. Users of this script should ensure that the TissDB instance is running and accessible at the specified `--base-url`.

--- a/quanta_tissu/integrations/importer_exporter/importer_exporter.py
+++ b/quanta_tissu/integrations/importer_exporter/importer_exporter.py
@@ -3,7 +3,8 @@ import json
 import csv
 import xml.etree.ElementTree as ET
 import argparse
-
+import sqlparse
+from sqlparse.sql import IdentifierList, Identifier
 # ==============================================================================
 # TissDB API Client
 # ==============================================================================
@@ -202,6 +203,190 @@ def import_from_xml(collection_name: str, file_path: str, base_url: str):
     except Exception as e:
         print(f"An unexpected error occurred: {e}")
 
+def export_to_sql(collection_name: str, file_path: str, base_url: str):
+    """
+    Exports all documents from a TissDB collection to a SQL file.
+    """
+    print(f"Starting export of collection '{collection_name}' to '{file_path}'...")
+    try:
+        client = TissDBAPIClient(base_url)
+        documents = client.get_all_documents(collection_name)
+
+        if not documents:
+            print("No documents found in the collection. Nothing to export.")
+            return
+
+        # Infer schema (column names and types)
+        header = set()
+        for doc in documents:
+            header.update(doc.keys())
+
+        sorted_header = sorted(list(header))
+
+        # Determine column types by checking all values
+        column_types = {}
+        for column in sorted_header:
+            has_real = False
+            has_integer = False
+            has_boolean = False
+            has_string = False
+
+            for doc in documents:
+                value = doc.get(column)
+                if value is None:
+                    continue
+
+                if isinstance(value, bool):
+                    has_boolean = True
+                elif isinstance(value, float):
+                    has_real = True
+                elif isinstance(value, int):
+                    has_integer = True
+                else:
+                    has_string = True
+
+            if has_string:
+                column_types[column] = "TEXT"
+            elif has_real:
+                column_types[column] = "REAL"
+            elif has_integer:
+                if has_boolean:
+                    column_types[column] = "TEXT"
+                else:
+                    column_types[column] = "INTEGER"
+            elif has_boolean:
+                column_types[column] = "BOOLEAN"
+            else:
+                column_types[column] = "TEXT"
+
+        # Generate CREATE TABLE statement
+        create_table_statement = f"CREATE TABLE IF NOT EXISTS `{collection_name}` (\n"
+        columns_definitions = []
+        for column in sorted_header:
+            columns_definitions.append(f"  `{column}` {column_types[column]}")
+        create_table_statement += ",\n".join(columns_definitions)
+        create_table_statement += "\n);"
+
+        # Generate INSERT statements
+        insert_statements = []
+        for doc in documents:
+            columns = []
+            values = []
+            for column in sorted_header:
+                if column in doc and doc[column] is not None:
+                    columns.append(f"`{column}`")
+                    value = doc[column]
+                    if isinstance(value, str):
+                        value_str = value.replace("'", "''")
+                        values.append(f"'{value_str}'")
+                    elif isinstance(value, bool):
+                        values.append("TRUE" if value else "FALSE")
+                    else:
+                        values.append(str(value))
+
+            if not columns:
+                continue
+
+            insert_statement = f"INSERT INTO `{collection_name}` ({', '.join(columns)}) VALUES ({', '.join(values)});"
+            insert_statements.append(insert_statement)
+
+        # Write to file
+        with open(file_path, 'w', encoding='utf-8') as f:
+            f.write(create_table_statement)
+            f.write("\n\n")
+            for stmt in insert_statements:
+                f.write(stmt)
+                f.write("\n")
+
+        print(f"Successfully exported {len(documents)} documents to '{file_path}'.")
+
+    except requests.exceptions.RequestException as e:
+        print(f"Error connecting to TissDB: {e}")
+    except IOError as e:
+        print(f"Error writing to file '{file_path}': {e}")
+    except Exception as e:
+        print(f"An unexpected error occurred: {e}")
+
+def import_from_sql(collection_name: str, file_path: str, base_url: str):
+    """
+    Imports documents from a SQL file into a TissDB collection.
+    """
+    print(f"Starting import from '{file_path}' to collection '{collection_name}'...")
+    try:
+        client = TissDBAPIClient(base_url)
+        count = 0
+
+        with open(file_path, 'r', encoding='utf-8') as f:
+            content = f.read()
+
+        statements = sqlparse.parse(content)
+
+        for stmt in statements:
+            if stmt.get_type() != 'INSERT':
+                continue
+
+            # Find the parenthesis tokens, expecting one for columns and one for values
+            parentheses = [t for t in stmt.tokens if isinstance(t, sqlparse.sql.Parenthesis)]
+            if len(parentheses) < 2:
+                continue
+
+            columns_part = None
+            values_part = None
+
+            # Find the VALUES keyword to correctly identify columns and values parentheses
+            values_keyword_found = False
+            for token in stmt.tokens:
+                if token.is_keyword and token.normalized == 'VALUES':
+                    values_keyword_found = True
+                if isinstance(token, sqlparse.sql.Parenthesis):
+                    if not values_keyword_found:
+                        columns_part = token
+                    else:
+                        values_part = token
+                        break # Found both, can stop
+
+            if not columns_part or not values_part:
+                continue
+
+            # Extract column names from the first parenthesis
+            identifiers = [t for t in columns_part.tokens if isinstance(t, Identifier)]
+            if not identifiers: # Check inside an IdentifierList
+                id_list = [t for t in columns_part.tokens if isinstance(t, IdentifierList)]
+                if id_list:
+                    identifiers = id_list[0].get_identifiers()
+
+            column_names = [i.get_real_name() for i in identifiers]
+
+            # Extract values from the second parenthesis
+            def _parse_sql_value(token):
+                if token.ttype in sqlparse.tokens.Literal.String.Single:
+                    return token.value[1:-1].replace("''", "'")
+                return token.value
+
+            value_tokens = [t for t in values_part.tokens if t.ttype is not None and not t.is_whitespace and t.value not in ('(', ')', ',')]
+            values = [_convert_value(_parse_sql_value(t)) for t in value_tokens]
+
+            if len(column_names) != len(values):
+                print(f"Warning: Mismatch between column count ({len(column_names)}) and value count ({len(values)}) in statement: {stmt}")
+                continue
+
+            document = dict(zip(column_names, values))
+            client.insert_document(collection_name, document)
+            count += 1
+            if count % 100 == 0:
+                print(f"Imported {count} documents...")
+
+        print(f"Successfully imported {count} documents from '{file_path}'.")
+
+    except FileNotFoundError:
+        print(f"Error: The file '{file_path}' was not found.")
+    except requests.exceptions.RequestException as e:
+        print(f"Error connecting to TissDB: {e}")
+    except IOError as e:
+        print(f"Error reading file '{file_path}': {e}")
+    except Exception as e:
+        print(f"An unexpected error occurred: {e}")
+
 # ==============================================================================
 # Command-Line Interface
 # ==============================================================================
@@ -213,7 +398,7 @@ def main():
     parser = argparse.ArgumentParser(description="TissDB Importer/Exporter Tool")
 
     parser.add_argument("action", choices=['import', 'export'], help="The action to perform: 'import' or 'export'.")
-    parser.add_argument("format", choices=['csv', 'xml'], help="The data format to use: 'csv' or 'xml'.")
+    parser.add_argument("format", choices=['csv', 'xml', 'sql'], help="The data format to use: 'csv', 'xml', or 'sql'.")
     parser.add_argument("collection", help="The name of the TissDB collection.")
     parser.add_argument("filepath", help="The path to the input/output file.")
     parser.add_argument("--base-url", default="http://localhost:8080", help="The base URL of the TissDB server.")
@@ -225,11 +410,15 @@ def main():
             import_from_csv(args.collection, args.filepath, args.base_url)
         elif args.format == 'xml':
             import_from_xml(args.collection, args.filepath, args.base_url)
+        elif args.format == 'sql':
+            import_from_sql(args.collection, args.filepath, args.base_url)
     elif args.action == 'export':
         if args.format == 'csv':
             export_to_csv(args.collection, args.filepath, args.base_url)
         elif args.format == 'xml':
             export_to_xml(args.collection, args.filepath, args.base_url)
+        elif args.format == 'sql':
+            export_to_sql(args.collection, args.filepath, args.base_url)
 
 if __name__ == "__main__":
     main()

--- a/quanta_tissu/integrations/importer_exporter/sample_data.sql
+++ b/quanta_tissu/integrations/importer_exporter/sample_data.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS `users` (
+  `id` INTEGER,
+  `name` TEXT,
+  `age` INTEGER,
+  `city` TEXT,
+  `is_member` BOOLEAN
+);
+
+INSERT INTO `users` (`id`, `name`, `age`, `city`, `is_member`) VALUES (1, 'Alice', 30, 'New York', TRUE);
+INSERT INTO `users` (`id`, `name`, `age`, `city`, `is_member`) VALUES (2, 'Bob', 25, 'Los Angeles', FALSE);
+INSERT INTO `users` (`id`, `name`, `age`, `city`, `is_member`) VALUES (3, 'Charlie', 35, 'Chicago', TRUE);
+INSERT INTO `users` (`id`, `name`, `age`, `city`) VALUES (4, 'David', 40, 'Houston');
+INSERT INTO `users` (`id`, `name`, `age`, `city`, `is_member`) VALUES (5, 'Eve', 28, 'Phoenix', TRUE);


### PR DESCRIPTION
This commit introduces the capability to import and export data to and from a TissDB collection using SQL files.

Key features include:
- `export_to_sql`: Fetches documents from a collection, infers a schema, and generates a SQL file with `CREATE TABLE` and `INSERT` statements.
- `import_from_sql`: Parses a `.sql` file using the `sqlparse` library to handle `INSERT` statements and imports the data into a collection.
- Adds `sql` as a new format option to the command-line interface.
- Includes a `sample_data.sql` file for testing.
- Updates the `README.md` with comprehensive documentation for the new feature, including usage examples and implementation details.