### PR TITLE
This commit contains two fixes to resolve a segmentation fault and a …

### DIFF
--- a/tissdb/storage/Utils.h
+++ b/tissdb/storage/Utils.h
@@ -95,7 +95,7 @@ namespace bp_tree_utils {
     inline void writeValLittle<std::string>(const std::string &val, FILE *stream) {
         size_t len = val.length();
         writeValLittle(len, stream);
-        fwrite(val.c_str(), 1, len, stream);
+        bp_tree_utils::fwrite(val.c_str(), 1, len, stream);
     }
 
     template<>
@@ -103,7 +103,7 @@ namespace bp_tree_utils {
         size_t len = readValLittle<size_t>(stream);
         if (len > 0) {
             std::vector<char> buf(len);
-            fread(buf.data(), 1, len, stream);
+            bp_tree_utils::fread(buf.data(), 1, len, stream);
             return std::string(buf.data(), len);
         }
         return "";


### PR DESCRIPTION
…subsequent compilation error.

1.  **Fix B-Tree Serialization Bug:**
    - A segmentation fault was occurring during the `BppTreeSerialization` test due to a memory corruption bug.
    - The root cause was unsafe serialization of `std::string` objects in `tissdb/storage/Utils.h`. The serialization logic performed a raw byte copy of the string object instead of its character data, leading to invalid pointers after deserialization.
    - This was fixed by adding template specializations for `std::string` in `Utils.h` to correctly serialize the string's length and character data.

2.  **Fix Compilation Error:**
    - The initial fix introduced a compilation error (`ambiguous call to fwrite/fread`).
    - This was caused by the new string serialization functions calling `fread` and `fwrite` without specifying a namespace, creating ambiguity between the helpers in `bp_tree_utils` and the standard library functions.
    - This was resolved by adding the `bp_tree_utils::` namespace qualifier to the function calls in `Utils.h`.