### PR TITLE
feat(tisslm): Allow generating text from a model checkpoint

### DIFF
--- a/quanta_tissu/tisslm/generate_text.py
+++ b/quanta_tissu/tisslm/generate_text.py
@@ -1,23 +1,19 @@
 import numpy as np
 import argparse
+import sys
+import os
 
 from .model import QuantaTissu
-from .tokenizer import detokenize, Tokenizer
-from .config import model_config, vocab
+from .tokenizer import Tokenizer
+from .config import model_config
 
-def generate_text(prompt: str, length: int) -> str:
+def generate_text(model: QuantaTissu, tokenizer: Tokenizer, prompt: str, length: int) -> str:
     """
     Generates text of a specified length, starting with a prompt.
     """
-    np.random.seed(42)  # for reproducibility
-    # NOTE: The tokenizer initialization is simplified here.
-    # In a real application, it should be loaded from a file.
-    tokenizer = Tokenizer(vocab)
-    model = QuantaTissu(model_config)
-
     # Tokenize the initial prompt
     prompt_token_ids = tokenizer.tokenize(prompt)
-    if not prompt_token_ids:
+    if not prompt_token_ids.any(): # Check if the array is not empty
         print("Warning: Prompt is empty or contains only unknown tokens.", file=sys.stderr)
         return ""
 
@@ -25,7 +21,7 @@ def generate_text(prompt: str, length: int) -> str:
     generated_ids = model.generate(prompt_token_ids, n_new_tokens=length, method="greedy")
 
     # The full sequence is the prompt + generated tokens
-    full_token_ids = prompt_token_ids + generated_ids
+    full_token_ids = np.concatenate([prompt_token_ids, generated_ids])
 
     # Detokenize the entire sequence of tokens
     return tokenizer.detokenize(full_token_ids)
@@ -47,14 +43,41 @@ def main():
         default="hello",
         help="The initial prompt to start generation."
     )
+    parser.add_argument(
+        "--checkpoint_path",
+        type=str,
+        required=True,
+        help="Path to the model checkpoint (.npz file)."
+    )
     args = parser.parse_args()
 
-    # Ensure the prompt is in the vocabulary
-    if args.prompt not in vocab:
-        print(f"Error: Prompt '{args.prompt}' not in vocabulary. Please use one of: {list(vocab.keys())}", file=sys.stderr)
+    # --- Initialize Tokenizer ---
+    # The Tokenizer class automatically loads the default tokenizer files.
+    # Make sure you have run train_bpe.py first.
+    try:
+        tokenizer = Tokenizer()
+    except FileNotFoundError as e:
+        print(f"Error: Tokenizer files not found. {e}", file=sys.stderr)
+        print("Please run `python3 -m quanta_tissu.tisslm.train_bpe` to train and save the tokenizer.", file=sys.stderr)
         sys.exit(1)
 
-    generated_text = generate_text(args.prompt, args.length)
+    # --- Initialize Model ---
+    # Update vocab_size in the model config based on the loaded tokenizer
+    model_config["vocab_size"] = tokenizer.get_vocab_size()
+
+    np.random.seed(42)  # for reproducibility
+    model = QuantaTissu(model_config)
+
+    # --- Load Checkpoint ---
+    if not os.path.exists(args.checkpoint_path):
+         print(f"Error: Checkpoint file not found at '{args.checkpoint_path}'", file=sys.stderr)
+         print("Please run `python3 -m quanta_tissu.tisslm.run_training` to train and save a model checkpoint.", file=sys.stderr)
+         sys.exit(1)
+    model.load_weights(args.checkpoint_path)
+    print(f"Successfully loaded model weights from {args.checkpoint_path}")
+
+
+    generated_text = generate_text(model, tokenizer, args.prompt, args.length)
     print(generated_text)
 
 if __name__ == "__main__":


### PR DESCRIPTION
Refactors the `generate_text.py` script to enable running inference from a saved model checkpoint.

The script now requires a `--checkpoint_path` argument to load the weights of a pre-trained model. The tokenizer loading has been corrected to use the class's default-loading mechanism, which resolves the `AttributeError` bug.

Error handling has also been improved to provide more instructive messages to the user if the required model or tokenizer files are not found.