### PR TITLE
Refactor: Create a dedicated JSON parser for nexus_flow

### DIFF
--- a/quanta_tissu/nexus_flow/graph_logic.cpp
+++ b/quanta_tissu/nexus_flow/graph_logic.cpp
@@ -13,6 +13,11 @@
 #include <windows.h> // For Windows-specific console functions
 #include <conio.h>   // For _getch()
 
+#include "json/json.h"
+
+// Type alias for convenience
+using Json = NexusFlow::Json::JsonValue;
+
 // --- 3D Math Utilities ---
 
 struct Point3D {
@@ -239,6 +244,12 @@ std::string GraphLogic::getUserPrompt() {
  * sizes, labels, and the edges connecting them. The data is designed to
  * demonstrate occlusion and various node sizes.
  */
+void GraphLogic::loadGraphsFromTissDB() {
+    // For this standalone example, we'll call the hardcoded graph initializer.
+    // In a real scenario, this would involve a network request to TissDB.
+    initializeGraphs();
+}
+
 void GraphLogic::initializeGraphs() {
     // Cognitive Behavioral Therapy related labels
     std::vector<std::string> cbt_labels = {

--- a/quanta_tissu/nexus_flow/json/json.cpp
+++ b/quanta_tissu/nexus_flow/json/json.cpp
@@ -1,0 +1,197 @@
+#include "json.h"
+#include <sstream>
+#include <cctype>
+#include <stdexcept>
+#include <vector>
+
+namespace NexusFlow {
+namespace Json {
+
+// --- Tokenizer ---
+
+enum class TokenType {
+    LEFT_BRACE, RIGHT_BRACE,
+    LEFT_BRACKET, RIGHT_BRACKET,
+    COMMA, COLON,
+    STRING, NUMBER, BOOLEAN, JSON_NULL,
+    END_OF_FILE
+};
+
+struct Token {
+    TokenType type;
+    std::string value;
+};
+
+class Tokenizer {
+public:
+    Tokenizer(const std::string& input) : text(input), pos(0) {}
+    std::vector<Token> tokenize() {
+        std::vector<Token> tokens;
+        while (pos < text.length()) {
+            char c = text[pos];
+            if (std::isspace(c)) { pos++; continue; }
+            switch (c) {
+                case '{': tokens.push_back({TokenType::LEFT_BRACE, "{"}); pos++; break;
+                case '}': tokens.push_back({TokenType::RIGHT_BRACE, "}"}); pos++; break;
+                case '[': tokens.push_back({TokenType::LEFT_BRACKET, "["}); pos++; break;
+                case ']': tokens.push_back({TokenType::RIGHT_BRACKET, "]"}); pos++; break;
+                case ',': tokens.push_back({TokenType::COMMA, ","}); pos++; break;
+                case ':': tokens.push_back({TokenType::COLON, ":"}); pos++; break;
+                case '"': tokens.push_back({TokenType::STRING, parse_string()}); break;
+                default:
+                    if (c == 't' || c == 'f') tokens.push_back({TokenType::BOOLEAN, parse_literal("true", "false")});
+                    else if (c == 'n') tokens.push_back({TokenType::JSON_NULL, parse_literal("null", "")});
+                    else if (std::isdigit(c) || c == '-') tokens.push_back({TokenType::NUMBER, parse_number()});
+                    else throw std::runtime_error("Tokenizer error: Unexpected character.");
+            }
+        }
+        tokens.push_back({TokenType::END_OF_FILE, ""});
+        return tokens;
+    }
+private:
+    std::string text; size_t pos;
+    std::string parse_string() {
+        pos++; std::stringstream ss;
+        while (pos < text.length() && text[pos] != '"') {
+            if (text[pos] == '\\') {
+                pos++;
+                if (pos >= text.length()) throw std::runtime_error("Unterminated string.");
+                switch (text[pos]) {
+                    case '"': ss << '"'; break; case '\\': ss << '\\'; break;
+                    case '/': ss << '/'; break; case 'b': ss << '\b'; break;
+                    case 'f': ss << '\f'; break; case 'n': ss << '\n'; break;
+                    case 'r': ss << '\r'; break; case 't': ss << '\t'; break;
+                    default: throw std::runtime_error("Invalid escape sequence.");
+                }
+            } else { ss << text[pos]; }
+            pos++;
+        }
+        if (pos >= text.length()) throw std::runtime_error("Unterminated string.");
+        pos++; return ss.str();
+    }
+    std::string parse_number() {
+        std::stringstream ss;
+        while (pos < text.length() && (std::isdigit(text[pos]) || text[pos] == '.' || text[pos] == '-' || text[pos] == 'e' || text[pos] == 'E' || text[pos] == '+')) {
+            ss << text[pos++];
+        }
+        return ss.str();
+    }
+    std::string parse_literal(const std::string& v1, const std::string& v2) {
+        if (text.substr(pos, v1.length()) == v1) { pos += v1.length(); return v1; }
+        if (!v2.empty() && text.substr(pos, v2.length()) == v2) { pos += v2.length(); return v2; }
+        throw std::runtime_error("Invalid literal.");
+    }
+};
+
+// --- Parser ---
+
+class Parser {
+public:
+    Parser(const std::vector<Token>& tokens) : tokens_(tokens), pos_(0) {}
+    JsonValue parse() {
+        JsonValue result = parse_value();
+        consume(TokenType::END_OF_FILE, "Expected end of input.");
+        return result;
+    }
+private:
+    const std::vector<Token>& tokens_; size_t pos_;
+    const Token& peek() const { return tokens_[pos_]; }
+    Token consume() { return tokens_[pos_++]; }
+    Token consume(TokenType type, const std::string& msg) {
+        Token t = consume();
+        if (t.type != type) throw std::runtime_error(msg);
+        return t;
+    }
+    JsonValue parse_value() {
+        switch (peek().type) {
+            case TokenType::LEFT_BRACE: return parse_object();
+            case TokenType::LEFT_BRACKET: return parse_array();
+            case TokenType::STRING: return JsonValue(consume().value);
+            case TokenType::NUMBER: return JsonValue(std::stod(consume().value));
+            case TokenType::BOOLEAN: return JsonValue(consume().value == "true");
+            case TokenType::JSON_NULL: consume(); return JsonValue(nullptr);
+            default: throw std::runtime_error("Unexpected token when parsing value.");
+        }
+    }
+    JsonValue parse_object() {
+        consume(TokenType::LEFT_BRACE, "Expected '{'.");
+        JsonObject obj;
+        if (peek().type != TokenType::RIGHT_BRACE) {
+            while (true) {
+                Token key = consume(TokenType::STRING, "Expected string key.");
+                consume(TokenType::COLON, "Expected ':'.");
+                obj[key.value] = parse_value();
+                if (peek().type == TokenType::RIGHT_BRACE) break;
+                consume(TokenType::COMMA, "Expected ','.");
+            }
+        }
+        consume(TokenType::RIGHT_BRACE, "Expected '}'.");
+        return JsonValue(obj);
+    }
+    JsonValue parse_array() {
+        consume(TokenType::LEFT_BRACKET, "Expected '['.");
+        JsonArray arr;
+        if (peek().type != TokenType::RIGHT_BRACKET) {
+            while (true) {
+                arr.push_back(parse_value());
+                if (peek().type == TokenType::RIGHT_BRACKET) break;
+                consume(TokenType::COMMA, "Expected ','.");
+            }
+        }
+        consume(TokenType::RIGHT_BRACKET, "Expected ']'.");
+        return JsonValue(arr);
+    }
+};
+
+// --- JsonValue::parse method ---
+
+JsonValue JsonValue::parse(const std::string& json_string) {
+    if (json_string.empty()) throw std::runtime_error("Cannot parse empty string.");
+    Tokenizer tokenizer(json_string);
+    std::vector<Token> tokens = tokenizer.tokenize();
+    Parser parser(tokens);
+    return parser.parse();
+}
+
+// --- JsonValue::serialize method ---
+
+std::string JsonValue::serialize() const {
+    std::stringstream ss;
+    std::visit(
+        [&ss](const auto& arg) {
+            using T = std::decay_t<decltype(arg)>;
+            if constexpr (std::is_same_v<T, JsonNull>) {
+                ss << "null";
+            } else if constexpr (std::is_same_v<T, bool>) {
+                ss << (arg ? "true" : "false");
+            } else if constexpr (std::is_same_v<T, double>) {
+                ss << arg;
+            } else if constexpr (std::is_same_v<T, std::string>) {
+                // A proper implementation would handle escape characters.
+                ss << '"' << arg << '"';
+            } else if constexpr (std::is_same_v<T, JsonArray>) {
+                ss << '[';
+                bool first = true;
+                for (const auto& val : arg) {
+                    if (!first) ss << ',';
+                    ss << val.serialize();
+                    first = false;
+                }
+                ss << ']';
+            } else if constexpr (std::is_same_v<T, JsonObject>) {
+                ss << '{';
+                bool first = true;
+                for (const auto& pair : arg) {
+                    if (!first) ss << ',';
+                    ss << '"' << pair.first << "\":" << pair.second.serialize();
+                    first = false;
+                }
+                ss << '}';
+            }
+        },
+        value_);
+    return ss.str();
+}
+
+} // namespace Json
+} // namespace NexusFlow

--- a/quanta_tissu/nexus_flow/json/json.h
+++ b/quanta_tissu/nexus_flow/json/json.h
@@ -1,0 +1,69 @@
+#pragma once
+
+#include <string>
+#include <vector>
+#include <map>
+#include <variant>
+#include <stdexcept>
+
+namespace NexusFlow {
+namespace Json {
+
+// Forward declaration for recursive data structures
+class JsonValue;
+
+// Define the types that make up a JSON structure
+using JsonObject = std::map<std::string, JsonValue>;
+using JsonArray = std::vector<JsonValue>;
+using JsonNull = std::nullptr_t;
+
+// A JsonValue can be any one of the valid JSON types.
+// We use std::variant to represent this polymorphic nature.
+class JsonValue {
+public:
+    using ValueType = std::variant<
+        JsonNull,
+        bool,
+        double,
+        std::string,
+        JsonArray,
+        JsonObject
+    >;
+
+    // Constructors
+    JsonValue() : value_(JsonNull{}) {}
+    JsonValue(JsonNull val) : value_(val) {}
+    JsonValue(bool val) : value_(val) {}
+    JsonValue(double val) : value_(val) {}
+    JsonValue(const char* val) : value_(std::string(val)) {}
+    JsonValue(const std::string& val) : value_(val) {}
+    JsonValue(const JsonArray& val) : value_(val) {}
+    JsonValue(const JsonObject& val) : value_(val) {}
+
+    // A static parsing function that will be implemented in json.cpp
+    static JsonValue parse(const std::string& json_string);
+
+    // A method to serialize the JsonValue back into a string.
+    std::string serialize() const;
+
+    // Type checking methods
+    bool is_null() const { return std::holds_alternative<JsonNull>(value_); }
+    bool is_bool() const { return std::holds_alternative<bool>(value_); }
+    bool is_number() const { return std::holds_alternative<double>(value_); }
+    bool is_string() const { return std::holds_alternative<std::string>(value_); }
+    bool is_array() const { return std::holds_alternative<JsonArray>(value_); }
+    bool is_object() const { return std::holds_alternative<JsonObject>(value_); }
+
+    // Value accessors (will throw if type is wrong)
+    bool as_bool() const { return std::get<bool>(value_); }
+    double as_number() const { return std::get<double>(value_); }
+    const std::string& as_string() const { return std::get<std::string>(value_); }
+    const JsonArray& as_array() const { return std::get<JsonArray>(value_); }
+    const JsonObject& as_object() const { return std::get<JsonObject>(value_); }
+
+private:
+    ValueType value_;
+};
+
+} // namespace Json
+} // namespace NexusFlow


### PR DESCRIPTION
This change introduces a dedicated JSON parser for the `nexus_flow` application to decouple it from the `tissdb` component.

The key changes are:
- Duplicated the existing JSON parser from `tissdb/json` into `quanta_tissu/nexus_flow/json`.
- Updated the namespace of the new parser to `NexusFlow::Json` to prevent conflicts.
- Modified `nexus_flow` to use its own dedicated parser.

This also includes the initial fixes to allow the `nexus_flow` application to be compiled on Windows.