### PR TITLE
feat(tissdb): Implement atomic transaction commit and rollback

### DIFF
--- a/tissdb/common/operation.h
+++ b/tissdb/common/operation.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <string>
+#include <vector>
+#include "document.h"
+
+namespace TissDB {
+namespace Transactions {
+
+// Defines the type of operation within a transaction.
+enum class OperationType {
+    PUT,
+    DELETE
+};
+
+// Represents a single operation (PUT or DELETE) within a transaction.
+struct Operation {
+    OperationType type;
+    std::string collection_name;
+    std::string key;
+    Document doc; // Used for PUT operations.
+};
+
+} // namespace Transactions
+} // namespace TissDB

--- a/tissdb/storage/lsm_tree.h
+++ b/tissdb/storage/lsm_tree.h
@@ -9,7 +9,7 @@
 #include "collection.h"
 #include "transaction_manager.h"
 #include "../common/schema.h"
-#include "transaction_manager.h"
+#include "wal.h"
 
 namespace TissDB {
 namespace Storage {
@@ -22,6 +22,10 @@ public:
     LSMTree(const std::string& path);
     ~LSMTree();
 
+    WriteAheadLog& get_wal() { return *wal_; }
+
+    // Recovery
+    void recover();
 
     // Collection management
     virtual void create_collection(const std::string& name, const TissDB::Schema& schema);
@@ -55,6 +59,7 @@ public:
 private:
     std::map<std::string, std::unique_ptr<Collection>> collections_;
     std::string path_;
+    std::unique_ptr<WriteAheadLog> wal_;
     Transactions::TransactionManager transaction_manager_;
 };
 

--- a/tissdb/storage/transaction_manager.h
+++ b/tissdb/storage/transaction_manager.h
@@ -8,6 +8,7 @@
 #include <string>
 
 #include "../common/document.h"
+#include "../common/operation.h"
 
 namespace TissDB {
 
@@ -18,18 +19,6 @@ class LSMTree; // Forward declaration
 namespace Transactions {
 
 using TransactionID = int;
-
-enum class OperationType {
-    PUT,
-    DELETE
-};
-
-struct Operation {
-    OperationType type;
-    std::string collection_name;
-    std::string key;
-    Document doc; // Used for PUT
-};
 
 class Transaction {
 public:

--- a/tissdb/storage/wal.cpp
+++ b/tissdb/storage/wal.cpp
@@ -32,16 +32,36 @@ void WriteAheadLog::append(const LogEntry& entry) {
 
     bsb.write(entry.type);
     bsb.write(entry.transaction_id);
-    bsb.write_string(entry.collection_name);
-    bsb.write_string(entry.document_id); // For collection ops, this can be empty
 
-    if (entry.type == LogEntryType::PUT) {
-        std::vector<uint8_t> doc_bytes = TissDB::serialize(entry.doc);
-        bsb.write_bytes(doc_bytes);
-    } else {
-        // For DELETE, CREATE_COLLECTION, DELETE_COLLECTION, no doc is needed.
-        size_t zero_len = 0;
-        bsb.write(zero_len);
+    switch (entry.type) {
+        case LogEntryType::PUT:
+            bsb.write_string(entry.collection_name);
+            bsb.write_string(entry.document_id);
+            bsb.write_bytes(TissDB::serialize(entry.doc));
+            break;
+        case LogEntryType::DELETE:
+            bsb.write_string(entry.collection_name);
+            bsb.write_string(entry.document_id);
+            break;
+        case LogEntryType::TXN_COMMIT: {
+            bsb.write(static_cast<uint64_t>(entry.operations.size()));
+            for (const auto& op : entry.operations) {
+                bsb.write(op.type);
+                bsb.write_string(op.collection_name);
+                bsb.write_string(op.key);
+                if (op.type == TissDB::Transactions::OperationType::PUT) {
+                    bsb.write_bytes(TissDB::serialize(op.doc));
+                }
+            }
+            break;
+        }
+        case LogEntryType::TXN_ABORT:
+            // Only type and TID are needed.
+            break;
+        case LogEntryType::CREATE_COLLECTION:
+        case LogEntryType::DELETE_COLLECTION:
+            bsb.write_string(entry.collection_name);
+            break;
     }
 
     std::string buffer_str = buffer_stream.str();
@@ -93,14 +113,38 @@ std::vector<LogEntry> WriteAheadLog::recover() {
             BinaryStreamBuffer entry_bsb(entry_stream);
             entry_bsb.read(entry.type);
             entry_bsb.read(entry.transaction_id);
-            entry.collection_name = entry_bsb.read_string();
-            entry.document_id = entry_bsb.read_string();
 
-            if (entry.type == LogEntryType::PUT) {
-                entry.doc = TissDB::deserialize(entry_bsb.read_bytes());
-            } else {
-                entry_bsb.read_bytes(); // Consume the empty bytes
-                entry.doc = Document{};
+            switch (entry.type) {
+                case LogEntryType::PUT:
+                    entry.collection_name = entry_bsb.read_string();
+                    entry.document_id = entry_bsb.read_string();
+                    entry.doc = TissDB::deserialize(entry_bsb.read_bytes());
+                    break;
+                case LogEntryType::DELETE:
+                    entry.collection_name = entry_bsb.read_string();
+                    entry.document_id = entry_bsb.read_string();
+                    break;
+                case LogEntryType::TXN_COMMIT: {
+                    uint64_t op_count;
+                    entry_bsb.read(op_count);
+                    for (uint64_t i = 0; i < op_count; ++i) {
+                        TissDB::Transactions::Operation op;
+                        entry_bsb.read(op.type);
+                        op.collection_name = entry_bsb.read_string();
+                        op.key = entry_bsb.read_string();
+                        if (op.type == TissDB::Transactions::OperationType::PUT) {
+                            op.doc = TissDB::deserialize(entry_bsb.read_bytes());
+                        }
+                        entry.operations.push_back(op);
+                    }
+                    break;
+                }
+                case LogEntryType::TXN_ABORT:
+                    break; // No more data to read
+                case LogEntryType::CREATE_COLLECTION:
+                case LogEntryType::DELETE_COLLECTION:
+                    entry.collection_name = entry_bsb.read_string();
+                    break;
             }
             recovered_entries.push_back(entry);
 

--- a/tissdb/storage/wal.h
+++ b/tissdb/storage/wal.h
@@ -8,6 +8,8 @@
 
 #include "../common/document.h"
 #include "../common/checksum.h"
+#include "../common/operation.h"
+
 
 namespace TissDB {
 namespace Storage {
@@ -26,11 +28,10 @@ enum class LogEntryType : uint8_t {
 struct LogEntry {
     LogEntryType type;
     int transaction_id = -1;
-    std::string collection_name; // Which collection this entry belongs to.
+    std::string collection_name;
     std::string document_id;
-    // For PUT operations, the full document is stored.
-    // For DELETE, only the document_id and collection_name are needed.
     Document doc;
+    std::vector<TissDB::Transactions::Operation> operations;
 };
 
 // Manages the Write-Ahead Log for ensuring durability of writes.


### PR DESCRIPTION
This change introduces a fully atomic transaction model to TissDB, ensuring durability and consistency through a Write-Ahead Log (WAL).

The key changes include:
- Refactoring the `TransactionManager` to use the WAL. Instead of applying operations directly, `commit_transaction` now writes a single `TXN_COMMIT` record containing all operations to the log. This ensures that transactions are atomic ("All or Nothing").
- Logging `TXN_ABORT` records for rolled-back transactions.
- Integrating a `WriteAheadLog` into the `LSMTree` lifecycle.
- Implementing a `recover()` method in `LSMTree` that replays the WAL upon database startup, restoring committed data and respecting aborted transactions.
- Extending the WAL's serialization logic to handle transactional entries.
- Adding a `TransactionRecovery` test case to verify that data from a committed transaction is durable and correctly restored after a restart.