### PR TITLE
feat(storage): Implement WAL for basic database persistence

### DIFF
--- a/tissdb/storage/lsm_tree.cpp
+++ b/tissdb/storage/lsm_tree.cpp
@@ -1,13 +1,33 @@
 #include "lsm_tree.h"
 #include "../common/log.h"
 #include <stdexcept>
+#include <filesystem>
 
 namespace TissDB {
 namespace Storage {
 
+void replay_log_entry(LSMTree* tree, const LogEntry& entry);
+
 LSMTree::LSMTree() : path_(""), transaction_manager_(*this) {}
 
-LSMTree::LSMTree(const std::string& path) : path_(path), transaction_manager_(*this) {}
+LSMTree::LSMTree(const std::string& path) : path_(path), transaction_manager_(*this) {
+    std::filesystem::path db_path(path_);
+    if (!std::filesystem::exists(db_path)) {
+        std::filesystem::create_directories(db_path);
+    }
+
+    std::string wal_path = db_path / "wal.log";
+    wal_ = std::make_unique<WriteAheadLog>(wal_path);
+
+    LOG_INFO("Starting recovery for database at: " + path);
+    auto log_entries = wal_->recover();
+    LOG_INFO("Found " + std::to_string(log_entries.size()) + " entries in WAL to replay.");
+
+    for (const auto& entry : log_entries) {
+        replay_log_entry(this, entry);
+    }
+    LOG_INFO("Recovery complete for database at: " + path);
+}
 
 LSMTree::~LSMTree() {}
 
@@ -16,6 +36,13 @@ void LSMTree::create_collection(const std::string& name, const TissDB::Schema& s
         LOG_ERROR("Attempted to create collection that already exists: " + name);
         throw std::runtime_error("Collection already exists: " + name);
     }
+
+    LogEntry entry;
+    entry.type = LogEntryType::CREATE_COLLECTION;
+    entry.collection_name = name;
+    // Note: Schema is not persisted in the WAL.
+    wal_->append(entry);
+
     LOG_INFO("Creating collection: " + name);
     auto collection = std::make_unique<Collection>(this);
     collection->set_schema(schema);
@@ -27,6 +54,12 @@ void LSMTree::delete_collection(const std::string& name) {
         LOG_ERROR("Attempted to delete collection that does not exist: " + name);
         throw std::runtime_error("Collection does not exist: " + name);
     }
+
+    LogEntry entry;
+    entry.type = LogEntryType::DELETE_COLLECTION;
+    entry.collection_name = name;
+    wal_->append(entry);
+
     LOG_INFO("Deleting collection: " + name);
     collections_.erase(name);
 }
@@ -43,11 +76,19 @@ void LSMTree::put(const std::string& collection_name, const std::string& key, co
     if (tid != -1) {
         transaction_manager_.add_put_operation(tid, collection_name, key, doc);
     } else {
+        LogEntry entry;
+        entry.type = LogEntryType::PUT;
+        entry.collection_name = collection_name;
+        entry.document_id = key;
+        entry.doc = doc;
+        wal_->append(entry);
+
         try {
             Collection& collection = get_collection(collection_name);
             collection.put(key, doc);
         } catch (const std::runtime_error& e) {
-            // Collection not found, ignore
+            // Collection not found, ignore.
+            // The WAL entry is still written, which is acceptable.
         }
     }
 }
@@ -83,11 +124,18 @@ void LSMTree::del(const std::string& collection_name, const std::string& key, Tr
     if (tid != -1) {
         transaction_manager_.add_delete_operation(tid, collection_name, key);
     } else {
+        LogEntry entry;
+        entry.type = LogEntryType::DELETE;
+        entry.collection_name = collection_name;
+        entry.document_id = key;
+        wal_->append(entry);
+
         try {
             Collection& collection = get_collection(collection_name);
             collection.del(key);
         } catch (const std::runtime_error& e) {
-            // Collection not found, ignore
+            // Collection not found, ignore.
+            // The WAL entry is still written, which is acceptable.
         }
     }
 }
@@ -157,6 +205,37 @@ std::vector<std::vector<std::string>> LSMTree::get_available_indexes(const std::
 
 void LSMTree::shutdown() {
     // Placeholder: Implement shutdown logic
+}
+
+void replay_log_entry(LSMTree* tree, const LogEntry& entry) {
+    switch (entry.type) {
+        case LogEntryType::CREATE_COLLECTION:
+            try {
+                // NOTE: The schema is not persisted in the WAL. Using an empty schema for recovery.
+                tree->create_collection(entry.collection_name, TissDB::Schema({}));
+            } catch (const std::runtime_error& e) {
+                // It's possible the collection already exists if the log has duplicate entries.
+                LOG_WARNING("During WAL replay, could not create collection '" + entry.collection_name + "': " + e.what());
+            }
+            break;
+        case LogEntryType::DELETE_COLLECTION:
+            try {
+                tree->delete_collection(entry.collection_name);
+            } catch (const std::runtime_error& e) {
+                LOG_WARNING("During WAL replay, could not delete collection '" + entry.collection_name + "': " + e.what());
+            }
+            break;
+        case LogEntryType::PUT:
+            tree->put(entry.collection_name, entry.document_id, entry.doc);
+            break;
+        case LogEntryType::DELETE:
+            tree->del(entry.collection_name, entry.document_id);
+            break;
+        case LogEntryType::TXN_COMMIT:
+        case LogEntryType::TXN_ABORT:
+            // Transaction replay logic is not yet implemented.
+            break;
+    }
 }
 
 } // namespace Storage

--- a/tissdb/storage/lsm_tree.h
+++ b/tissdb/storage/lsm_tree.h
@@ -9,7 +9,7 @@
 #include "collection.h"
 #include "transaction_manager.h"
 #include "../common/schema.h"
-#include "transaction_manager.h"
+#include "wal.h"
 
 namespace TissDB {
 namespace Storage {
@@ -55,6 +55,7 @@ public:
 private:
     std::map<std::string, std::unique_ptr<Collection>> collections_;
     std::string path_;
+    std::unique_ptr<WriteAheadLog> wal_;
     Transactions::TransactionManager transaction_manager_;
 };
 


### PR DESCRIPTION
Implements a Write-Ahead Log (WAL) to provide basic data persistence for the TissDB database engine.

The core changes include:
- The `LSMTree` constructor now recovers database state by replaying entries from a `wal.log` file on startup.
- Data modification operations (`create_collection`, `delete_collection`, `put`, `del`) now write to the WAL before being applied to the in-memory store.
- A `WriteAheadLog` class handles the low-level details of reading from and writing to the log file, including checksum verification.

This change addresses the issue of data being lost when the server stops.

Known limitations:
- Transactional operations are not yet persisted.
- Collection schemas are not persisted in the WAL.
- The WAL file is not truncated or checkpointed and will grow indefinitely.