### PR TITLE
Fix compilation error in lsm_tree.cpp

### DIFF
--- a/tissdb/storage/lsm_tree.cpp
+++ b/tissdb/storage/lsm_tree.cpp
@@ -17,7 +17,7 @@ LSMTree::LSMTree(const std::string& path) : path_(path), transaction_manager_(*t
         std::filesystem::create_directories(db_path);
     }
 
-    std::string wal_path = db_path / "wal.log";
+    std::string wal_path = (db_path / "wal.log").string();
     wal_ = std::make_unique<WriteAheadLog>(wal_path);
 
     LOG_INFO("Database opened at: " + path_ + ". Starting recovery.");


### PR DESCRIPTION
Resolved a compilation error caused by an incorrect type conversion from `std::filesystem::path` to `std::string`. The `path` object is now correctly converted to a string using the `.string()` method before being assigned to the `wal_path` variable.