### PR TITLE
docs: Create BDD status and remediation plan

### DIFF
--- a/docs/current_bdd_status_and_remediation.md
+++ b/docs/current_bdd_status_and_remediation.md
@@ -1,0 +1,75 @@
+# TissDB: BDD Test Status and Remediation Plan
+
+## 1. Introduction
+
+This document provides an up-to-date analysis of the current failures in the TissDB Behavior-Driven Development (BDD) test suite as of August 2025. It identifies the root causes of the errors and proposes a concrete remediation plan to bring the tests to a passing state.
+
+This analysis is based on the most recent test logs and supersedes any previous analysis documents, such as `docs/bdd_error_analysis.md`, which are now outdated.
+
+## 2. High-Level Summary
+
+The BDD test suite is currently in a critical state with a high number of failures across multiple features. The vast majority of these failures are not due to issues in the test code itself, but rather stem from a cascade of server-side errors, beginning with a critical failure during database initialization.
+
+The primary blocker is a recurring `500 Internal Server Error` that prevents the TissLM and KnowledgeBase components from being initialized, causing a domino effect of failures in dependent tests.
+
+## 3. Detailed Error Analysis
+
+The test failures can be grouped into the following categories:
+
+### Category 1: Critical - `500 Internal Server Error` on Database Setup
+- **Features Affected**: `generate`, `knowledge_base`, `kv_cache`, `predict`
+- **Symptom**: All scenarios in these features fail during the setup step (`Given a model and tokenizer` or `Given a knowledge base...`). The traceback points to `requests.exceptions.HTTPError: 500 Server Error: Internal Server Error for url: http://127.0.0.1:8080/testdb` which originates in the `_setup_database` method of the `KnowledgeBase` class.
+- **Hypothesis**: The TissDB server is running, but it encounters a fatal error when the `KnowledgeBase` attempts to perform its initial setup. This could be due to a malformed request from the client or a bug in the server's handling of that specific setup routine.
+
+### Category 2: Critical - Transaction Failures
+- **Feature Affected**: `database.feature`
+- **Symptom**: The "Basic transaction operations" and "Rollback transaction" scenarios fail with `AssertionError`. The tests expect a `200 OK` or `204 No Content` status code for `commit` and `rollback` operations, but the server is returning a different, unsuccessful status code.
+- **Hypothesis**: The server's transaction management endpoints (`/commit`, `/rollback`) are not implemented correctly. They either fail to perform the operation or do not return the expected success status code.
+
+### Category 3: Major - Data Type and Content Mismatches
+- **Features Affected**: `extended_database_tests.feature`, `update_delete_queries.feature`, `select_queries.feature`
+- **Symptoms**:
+    1.  `NameError: name 'true' is not defined`: This occurs in the `document_should_have_content` step because it uses `eval()` on a JSON string with boolean literals (`true`/`false`), which are not valid in Python.
+    2.  `AssertionError: Mismatch for key 'price': expected '1200', got '1250'`: This indicates that an `UPDATE` query is not producing the correct result.
+    3.  `AssertionError: No document found with 'price' = 20`: This happens because the test is comparing an integer `20` with a string value `'20'` returned from the database, indicating a type inconsistency.
+- **Hypothesis**: There are bugs in both the test implementation (improper use of `eval`) and the database's query engine, particularly in how it handles data types in `WHERE` clauses and `UPDATE` statements.
+
+### Category 4: Minor - Missing Step Definitions
+- **Features Affected**: `select_queries.feature`, `integration.feature`
+- **Symptom**: Many scenarios show `WARNING - No step definition found`, which leads to subsequent `KeyError: 'query_result'` because the context variable is never set.
+- **Hypothesis**: The test suite is incomplete. The steps have been written in the `.feature` files but have not been implemented in the Python step definition files.
+
+### Category 5: Major - Core Document Operation Failures
+- **Feature Affected**: `more_database_tests.feature`
+- **Symptoms**:
+    1.  `AssertionError: Document with ID doc_a not found in list`: The endpoint to list all documents in a collection is not returning the expected documents.
+    2.  `AssertionError` when attempting to create a collection that already exists. The server returns an unexpected status code.
+    3.  `AssertionError` when attempting to delete a non-existent document. The server returns an unexpected status code (not the expected `404 Not Found`).
+- **Hypothesis**: There are fundamental bugs in the server's core CRUD (Create, Read, Update, Delete) logic for collections and documents.
+
+## 4. Remediation Plan
+
+The following steps should be taken to resolve the BDD test failures, in order of priority:
+
+1.  **Stabilize the Server**:
+    - **Action**: Investigate and fix the root cause of the `500 Internal Server Error` during database setup.
+    - **Priority**: **Highest**. This is the primary blocker for a large portion of the test suite.
+    - **Suggestion**: Start by examining the `server.log` file for server-side stack traces. Add detailed logging to the server's main request handler and the code path triggered by the `KnowledgeBase` setup to pinpoint the exact line of failure.
+
+2.  **Fix Transaction Endpoints**:
+    - **Action**: Debug and correct the implementation of the `/commit` and `/rollback` endpoints in the TissDB server to ensure they perform the correct operations and return a `200` or `204` status code on success.
+    - **Priority**: High.
+
+3.  **Correct BDD Test Step Implementations**:
+    - **Action**:
+        - Replace the use of `eval(json_string)` with `json.loads(json_string)` in the test steps to correctly parse JSON data.
+        - Modify assertions to handle data type differences (e.g., convert values to the same type before comparison).
+    - **Priority**: Medium. These are client-side fixes that can be done in parallel with server-side work.
+
+4.  **Implement Missing BDD Steps**:
+    - **Action**: Write the Python code for all the missing step definitions in the `select_queries.feature` and `integration.feature` files.
+    - **Priority**: Medium. This is necessary to achieve full test coverage.
+
+5.  **Address Core Document and Collection Bugs**:
+    - **Action**: Debug and fix the server-side logic for listing documents, creating collections that already exist, and deleting non-existent documents to ensure they match the behavior expected by the tests.
+    - **Priority**: Low. These can be addressed after the more critical server stability issues are resolved.


### PR DESCRIPTION
This commit adds a new documentation file,
`docs/current_bdd_status_and_remediation.md`, which provides a detailed analysis of the current BDD test failures and a prioritized plan for their remediation.

The new document addresses the fact that previous analysis files were outdated and did not reflect the current state of the test suite, which is primarily affected by server-side `500 Internal Server Error` responses.