### PR TITLE
feat: Disable KnowledgeBase by default

### DIFF
--- a/quanta_tissu/tisslm/model.py
+++ b/quanta_tissu/tisslm/model.py
@@ -80,7 +80,7 @@ class PositionalEncoding:
         return x + self.pe[np.newaxis, positions, :]
 
 class QuantaTissu:
-    def __init__(self, config, db_host='127.0.0.1', db_port=8080, use_db=True):
+    def __init__(self, config, db_host='127.0.0.1', db_port=8080, use_db=False):
         self.config = config
         d_model = config["d_model"]
         vocab_size = config["vocab_size"]


### PR DESCRIPTION
Changes the default value of `use_db` in the `QuantaTissu` model constructor from `True` to `False`. This prevents the model from requiring a database connection to run, which simplifies its use.

This commit also includes previous changes to add inference-time tuning parameters (`--method`, `--temperature`, etc.) to the `generate_text.py` script to improve output quality.