### PR TITLE
Fix transaction management for /commit and /rollback

### DIFF
--- a/tissdb/storage/transaction_manager.cpp
+++ b/tissdb/storage/transaction_manager.cpp
@@ -13,11 +13,11 @@ TransactionID TransactionManager::begin_transaction() {
     return new_tid;
 }
 
-void TransactionManager::commit_transaction(TransactionID tid) {
+bool TransactionManager::commit_transaction(TransactionID tid) {
     std::lock_guard<std::mutex> lock(mutex_);
     auto it = transactions_.find(tid);
     if (it == transactions_.end() || it->second->get_state() != Transaction::State::ACTIVE) {
-        throw std::runtime_error("Cannot commit transaction: not active or does not exist.");
+        return false;
     }
 
     auto& transaction = it->second;
@@ -41,13 +41,14 @@ void TransactionManager::commit_transaction(TransactionID tid) {
 
     transaction->set_state(Transaction::State::COMMITTED);
     transactions_.erase(it);
+    return true;
 }
 
-void TransactionManager::rollback_transaction(TransactionID tid) {
+bool TransactionManager::rollback_transaction(TransactionID tid) {
     std::lock_guard<std::mutex> lock(mutex_);
     auto it = transactions_.find(tid);
     if (it == transactions_.end() || it->second->get_state() != Transaction::State::ACTIVE) {
-        return; // Idempotent
+        return true; // Idempotent
     }
 
     Storage::LogEntry abort_entry;
@@ -57,6 +58,7 @@ void TransactionManager::rollback_transaction(TransactionID tid) {
 
     it->second->set_state(Transaction::State::ABORTED);
     transactions_.erase(it);
+    return true;
 }
 
 void TransactionManager::add_put_operation(TransactionID tid, std::string collection, std::string key, Document doc) {

--- a/tissdb/storage/transaction_manager.h
+++ b/tissdb/storage/transaction_manager.h
@@ -52,8 +52,8 @@ public:
         : lsm_tree_(lsm_tree), next_transaction_id_(1) {}
 
     TransactionID begin_transaction();
-    void commit_transaction(TransactionID tid);
-    void rollback_transaction(TransactionID tid);
+    bool commit_transaction(TransactionID tid);
+    bool rollback_transaction(TransactionID tid);
 
     void add_put_operation(TransactionID tid, std::string collection, std::string key, Document doc);
     void add_delete_operation(TransactionID tid, std::string collection, std::string key);


### PR DESCRIPTION
The previous implementation incorrectly tied transaction state to the client socket, which is unreliable in a stateless HTTP environment.

This change refactors the transaction handling to be stateless from the server's perspective.

- The /begin endpoint now returns a JSON object with the transaction ID.
- The /commit and /rollback endpoints now expect the transaction ID in the request body.
- A new X-Transaction-ID header is used to pass the transaction context for other operations like PUT, GET, and DELETE.
- The underlying TransactionManager methods now return a boolean to indicate success, improving error handling.