### PR TITLE
Fix transaction management and compilation errors

### DIFF
--- a/tissdb/common/serialization.h
+++ b/tissdb/common/serialization.h
@@ -1,7 +1,8 @@
 #pragma once
 
 #include "document.h"
-#include "binary_stream_buffer.h" // Include the new header
+#include "binary_stream_buffer.h"
+#include "schema.h"
 #include <vector>
 
 namespace TissDB {
@@ -11,5 +12,11 @@ std::vector<uint8_t> serialize(const Document& doc);
 
 // Deserializes a document from a byte vector.
 Document deserialize(const std::vector<uint8_t>& bytes);
+
+// Serializes a schema to a byte vector.
+std::vector<uint8_t> serialize(const Schema& schema);
+
+// Deserializes a schema from a byte vector.
+Schema deserialize_schema(const std::vector<uint8_t>& bytes);
 
 } // namespace TissDB

--- a/tissdb/storage/lsm_tree.cpp
+++ b/tissdb/storage/lsm_tree.cpp
@@ -226,12 +226,12 @@ Transactions::TransactionID LSMTree::begin_transaction() {
     return transaction_manager_.begin_transaction();
 }
 
-void LSMTree::commit_transaction(Transactions::TransactionID transaction_id) {
-    transaction_manager_.commit_transaction(transaction_id);
+bool LSMTree::commit_transaction(Transactions::TransactionID transaction_id) {
+    return transaction_manager_.commit_transaction(transaction_id);
 }
 
-void LSMTree::rollback_transaction(Transactions::TransactionID transaction_id) {
-    transaction_manager_.rollback_transaction(transaction_id);
+bool LSMTree::rollback_transaction(Transactions::TransactionID transaction_id) {
+    return transaction_manager_.rollback_transaction(transaction_id);
 }
 
 bool LSMTree::has_index(const std::string& /*collection_name*/, const std::vector<std::string>& /*field_names*/) {

--- a/tissdb/storage/lsm_tree.h
+++ b/tissdb/storage/lsm_tree.h
@@ -45,8 +45,8 @@ public:
 
     // Transaction management
     Transactions::TransactionID begin_transaction();
-    void commit_transaction(Transactions::TransactionID transaction_id);
-    void rollback_transaction(Transactions::TransactionID transaction_id);
+    bool commit_transaction(Transactions::TransactionID transaction_id);
+    bool rollback_transaction(Transactions::TransactionID transaction_id);
 
     // Helper to get a collection, throws if not found
     Collection& get_collection(const std::string& name);


### PR DESCRIPTION
This patch addresses several issues:
1.  It fixes compilation errors related to incorrect method signatures for transaction management and a missing header file.
2.  It refactors the transaction handling in the HTTP server to be stateless and more robust.

The previous implementation incorrectly tied transaction state to the client socket, which is unreliable in a stateless HTTP environment. This has been changed to a model where the client passes the transaction ID.

Changes include:
- The /begin endpoint now returns a JSON object with the transaction ID.
- The /commit and /rollback endpoints now expect the transaction ID in the request body.
- A new X-Transaction-ID header is used to pass the transaction context for other operations like PUT, GET, and DELETE.
- The underlying TransactionManager and LSMTree methods now return a boolean to indicate success, improving error handling.
- A missing include for `schema.h` in `serialization.h` has been added.