### PR TITLE
Fix C++ compilation errors in the nexus_flow application.

### DIFF
--- a/quanta_tissu/nexus_flow/graph_logic.cpp
+++ b/quanta_tissu/nexus_flow/graph_logic.cpp
@@ -160,11 +160,16 @@ void GraphLogic::runGenerationWorkflow() {
         Json parsed_json = Json::parse(json_output);
 
         // Check for an error message from the Python script
-        if (parsed_json.type() == Json::Type::OBJECT && parsed_json.as_object().count("error")) {
+        if (parsed_json.is_object() && parsed_json.as_object().count("error")) {
             clearCanvas();
             canvas[5] = "  An error occurred during graph generation:";
-            std::string error_details = parsed_json["message"].as_string();
-            canvas[7] = "  " + error_details.substr(0, SCREEN_WIDTH - 4);
+            // Safe access to the "message" field
+            const auto& obj = parsed_json.as_object();
+            auto it = obj.find("message");
+            if (it != obj.end()) {
+                std::string error_details = it->second.as_string();
+                canvas[7] = "  " + error_details.substr(0, SCREEN_WIDTH - 4);
+            }
             renderCanvas();
             waitForSpacebar();
             return;
@@ -172,11 +177,13 @@ void GraphLogic::runGenerationWorkflow() {
 
         // Populate the graph object from the parsed JSON
         Graph g;
-        const Json& nodes_json = parsed_json["nodes"];
+        const auto& root_obj = parsed_json.as_object();
+        const Json& nodes_json = root_obj.at("nodes");
         for (const auto& node_json : nodes_json.as_array()) {
             Node n;
-            n.id = node_json["id"].as_integer();
-            n.label = node_json["label"].as_string();
+            const auto& node_obj = node_json.as_object();
+            n.id = static_cast<int>(node_obj.at("id").as_number());
+            n.label = node_obj.at("label").as_string();
             // Assign random positions for visualization
             n.x = (rand() % (SCREEN_WIDTH - 15)) + 5;
             n.y = (rand() % (SCREEN_HEIGHT - 5)) + 2;
@@ -185,11 +192,12 @@ void GraphLogic::runGenerationWorkflow() {
             g.nodes.push_back(n);
         }
 
-        const Json& edges_json = parsed_json["edges"];
+        const Json& edges_json = root_obj.at("edges");
         for (const auto& edge_json : edges_json.as_array()) {
             Edge e;
-            e.node1_id = edge_json["from"].as_integer();
-            e.node2_id = edge_json["to"].as_integer();
+            const auto& edge_obj = edge_json.as_object();
+            e.node1_id = static_cast<int>(edge_obj.at("from").as_number());
+            e.node2_id = static_cast<int>(edge_obj.at("to").as_number());
             g.edges.push_back(e);
         }
 
@@ -287,34 +295,17 @@ void GraphLogic::initializeGraphs() {
     g2.edges = {{1, 2}, {1, 8}, {2, 4}, {3, 4}, {4, 5}, {5, 7}, {6, 7}, {7, 8}};
     graphs.push_back(g2);
 
-            // Extract nodes
-            const Json& nodes_json = graph_doc["nodes"];
-            for (const auto& node_json : nodes_json.as_array()) {
-                Node n;
-                n.id = node_json["id"].as_integer();
-                n.x = node_json["x"].as_integer();
-                n.y = node_json["y"].as_integer();
-            n.z = (rand() % 20) - 10; // Assign random Z for 3D effect
-                n.size = node_json["size"].as_integer();
-                n.label = node_json["label"].as_string();
-                g.nodes.push_back(n);
-            }
-
-            // Extract edges
-            const Json& edges_json = graph_doc["edges"];
-            for (const auto& edge_json : edges_json.as_array()) {
-                Edge e;
-                e.node1_id = edge_json["from"].as_integer();
-                e.node2_id = edge_json["to"].as_integer();
-                g.edges.push_back(e);
-            }
-
-            graphs.push_back(g);
-        } catch (const std::exception& e) {
-            std::cerr << "Error parsing JSON for graph " << i << ": " << e.what() << std::endl;
-        }
-    }
-
+    // NOTE: The following block was syntactically incorrect and referred to
+    // variables not in scope. It has been removed. It appeared to be a
+    // copy-paste error from another part of the codebase.
+    //
+    //      // Extract nodes
+    //      const Json& nodes_json = graph_doc["nodes"];
+    //      ...
+    //      } catch (const std::exception& e) {
+    //          std::cerr << "Error parsing JSON for graph " << i << ": " << e.what() << std::endl;
+    //      }
+    //  }
 }
 
 /**

--- a/quanta_tissu/nexus_flow/graph_logic.h
+++ b/quanta_tissu/nexus_flow/graph_logic.h
@@ -70,6 +70,7 @@ private:
     // Helper methods
     std::string getUserPrompt();
     void loadGraphsFromTissDB();
+    void initializeGraphs();
 
     // Drawing functions
     void clearCanvas();


### PR DESCRIPTION
The following changes were made to `quanta_tissu/nexus_flow/`:

- Corrected the usage of the custom JSON library in `graph_logic.cpp` to align with the API defined in `json.h`. This involved replacing incorrect method calls for type checking and object property access (`.type()`, `[]`, `.as_integer()`) with the correct ones (`.is_object()`, `.as_object().at()`, `.as_number()`).
- Added the missing function declaration for `initializeGraphs()` to the `graph_logic.h` header file, resolving a linker error.
- Removed a syntactically incorrect and non-functional `try-catch` block from `graph_logic.cpp` that was causing a compilation failure.