### PR TITLE
Fix compilation error from recursive Value definition

### DIFF
--- a/tissdb/Makefile
+++ b/tissdb/Makefile
@@ -17,6 +17,7 @@ SRCS = main.cpp \
        api/http_server.cpp \
        common/binary_stream_buffer.cpp \
        common/checksum.cpp \
+       common/document.cpp \
        common/serialization.cpp \
        common/schema_validator.cpp \
        json/json.cpp \

--- a/tissdb/common/document.cpp
+++ b/tissdb/common/document.cpp
@@ -1,0 +1,40 @@
+#include "document.h"
+#include <iostream>
+
+namespace TissDB {
+
+// Custom equality check for our Value variant
+bool operator==(const Value& lhs, const Value& rhs) {
+    if (lhs.index() != rhs.index()) {
+        return false;
+    }
+    if (lhs.valueless_by_exception()) {
+        return true;
+    }
+
+    return std::visit(
+        [](const auto& a, const auto& b) -> bool {
+            using T = std::decay_t<decltype(a)>;
+
+            if constexpr (std::is_same_v<T, std::unique_ptr<Array>>) {
+                if (a && b) return *a == *b;
+                return !a && !b;
+            } else if constexpr (std::is_same_v<T, std::unique_ptr<Object>>) {
+                if (a && b) return *a == *b;
+                return !a && !b;
+            } else {
+                return a == b;
+            }
+        },
+        lhs, rhs);
+}
+
+bool Array::operator==(const Array& other) const {
+    return values == other.values;
+}
+
+bool Object::operator==(const Object& other) const {
+    return values == other.values;
+}
+
+} // namespace TissDB

--- a/tissdb/common/document.h
+++ b/tissdb/common/document.h
@@ -7,11 +7,13 @@
 #include <map>
 #include <variant>
 #include <chrono>
+#include <memory>
 
 namespace TissDB {
 
-// Forward declaration for recursive Element structure
 class Element;
+struct Array;
+struct Object;
 
 // Primitive types supported by TissDB
 using Number = double; // Using double to handle both integer and float values
@@ -19,7 +21,6 @@ using Boolean = bool;
 using DateTime = std::chrono::time_point<std::chrono::system_clock>;
 using BinaryData = std::vector<uint8_t>;
 
-// An Element's value can be a single primitive or a list of nested Elements.
 using Value = std::variant<
     std::nullptr_t,
     std::string,
@@ -27,10 +28,22 @@ using Value = std::variant<
     Boolean,
     DateTime,
     BinaryData,
-    std::vector<Element>, // For nested elements like <specs> or <reviews> in the example
-    std::vector<Value>,
-    std::map<std::string, Value>
+    std::vector<Element>,
+    std::unique_ptr<Array>,
+    std::unique_ptr<Object>
 >;
+
+bool operator==(const Value& lhs, const Value& rhs);
+
+struct Array {
+    std::vector<Value> values;
+    bool operator==(const Array& other) const;
+};
+
+struct Object {
+    std::map<std::string, Value> values;
+    bool operator==(const Object& other) const;
+};
 
 // An Element is a key-value pair, representing a tag in the document.
 class Element {


### PR DESCRIPTION
The `Value` type alias was defined recursively within a `std::variant`, which is not allowed in C++ and caused a compilation failure.

This was resolved by wrapping the recursive array and object types in `std::unique_ptr<Array>` and `std::unique_ptr<Object>` to break the direct recursion.

This change required implementing custom equality operators for `Value`, `Array`, and `Object` to handle `std::unique_ptr` comparison, which were added in a new `common/document.cpp` file.

The `Makefile` was updated to include the new source file.

Subsequent compilation errors in `api/http_server.cpp` were also fixed. This included adding the `Json::` namespace for `JsonValue` and updating the `value_to_json` and `json_to_value` functions to correctly handle the new `Value` structure.