### PR TITLE
Fix compilation errors from recursive Value definition

### DIFF
--- a/tissdb/api/http_server.cpp
+++ b/tissdb/api/http_server.cpp
@@ -69,7 +69,7 @@ Json::JsonValue value_to_json(const Value& value) {
         return Json::JsonValue(*num_val);
     } else if (const auto* bool_val = std::get_if<bool>(&value)) {
         return Json::JsonValue(*bool_val);
-    } else if (const auto* arr_ptr = std::get_if<std::unique_ptr<Array>>(&value)) {
+    } else if (const auto* arr_ptr = std::get_if<std::shared_ptr<Array>>(&value)) {
         Json::JsonArray arr;
         if (arr_ptr && *arr_ptr) {
             for (const auto& v : (*arr_ptr)->values) {
@@ -77,7 +77,7 @@ Json::JsonValue value_to_json(const Value& value) {
             }
         }
         return Json::JsonValue(arr);
-    } else if (const auto* obj_ptr = std::get_if<std::unique_ptr<Object>>(&value)) {
+    } else if (const auto* obj_ptr = std::get_if<std::shared_ptr<Object>>(&value)) {
         Json::JsonObject obj;
         if (obj_ptr && *obj_ptr) {
             for (const auto& [k, v] : (*obj_ptr)->values) {
@@ -131,13 +131,13 @@ Value json_to_value(const Json::JsonValue& json_val) {
     } else if (json_val.is_bool()) {
         return json_val.as_bool();
     } else if (json_val.is_array()) {
-        auto arr = std::make_unique<Array>();
+        auto arr = std::make_shared<Array>();
         for (const auto& v : json_val.as_array()) {
             arr->values.push_back(json_to_value(v));
         }
         return arr;
     } else if (json_val.is_object()) {
-        auto obj = std::make_unique<Object>();
+        auto obj = std::make_shared<Object>();
         for (const auto& [k, v] : json_val.as_object()) {
             obj->values[k] = json_to_value(v);
         }

--- a/tissdb/common/document.cpp
+++ b/tissdb/common/document.cpp
@@ -16,10 +16,10 @@ bool operator==(const Value& lhs, const Value& rhs) {
         [](const auto& a, const auto& b) -> bool {
             using T = std::decay_t<decltype(a)>;
 
-            if constexpr (std::is_same_v<T, std::unique_ptr<Array>>) {
+            if constexpr (std::is_same_v<T, std::shared_ptr<Array>>) {
                 if (a && b) return *a == *b;
                 return !a && !b;
-            } else if constexpr (std::is_same_v<T, std::unique_ptr<Object>>) {
+            } else if constexpr (std::is_same_v<T, std::shared_ptr<Object>>) {
                 if (a && b) return *a == *b;
                 return !a && !b;
             } else {

--- a/tissdb/common/document.h
+++ b/tissdb/common/document.h
@@ -29,8 +29,8 @@ using Value = std::variant<
     DateTime,
     BinaryData,
     std::vector<Element>,
-    std::unique_ptr<Array>,
-    std::unique_ptr<Object>
+    std::shared_ptr<Array>,
+    std::shared_ptr<Object>
 >;
 
 bool operator==(const Value& lhs, const Value& rhs);


### PR DESCRIPTION
Addresses a series of compilation errors related to the `Value` type definition in `common/document.h`.

The initial error was caused by a recursive `std::variant` definition. This was resolved by wrapping the recursive `Array` and `Object` types in smart pointers.

Initially, `std::unique_ptr` was used, which solved the recursion but made the `Value` and `Element` types non-copyable, leading to further compilation errors. This was fixed by switching to `std::shared_ptr`.

Cascading type errors and necessary implementation details in `api/http_server.cpp` and `common/document.cpp` related to these changes have also been fixed. The `Makefile` was updated to include the new `common/document.cpp` source file.