### PR TITLE
This commit resolves several C++ compilation errors in the `nexus_flo…

### DIFF
--- a/quanta_tissu/nexus_flow/graph_logic.cpp
+++ b/quanta_tissu/nexus_flow/graph_logic.cpp
@@ -271,18 +271,18 @@ void GraphLogic::initializeGraphs() {
 
     // Graph 1: 4 Nodes
     Graph g1;
-    g1.nodes = {
+    g1.nodes = std::vector<Node>{
         {1, 10, 5, 5, cbt_labels[0]},
         {2, 30, 15, 3, cbt_labels[1]},
         {3, 50, 8, 5, cbt_labels[2]},
         {4, 25, 2, 1, cbt_labels[3]}
     };
-    g1.edges = {{1, 2}, {1, 3}, {2, 3}, {2, 4}};
+    g1.edges = std::vector<Edge>{{1, 2}, {1, 3}, {2, 3}, {2, 4}};
     graphs.push_back(g1);
 
     // Graph 2: 8 Nodes (demonstrates occlusion)
     Graph g2;
-    g2.nodes = {
+    g2.nodes = std::vector<Node>{
         {1, 5, 3, 5, cbt_labels[4]},
         {2, 20, 10, 3, cbt_labels[5]},
         {3, 18, 9, 1, cbt_labels[6]}, // Occluded by node 2
@@ -292,7 +292,7 @@ void GraphLogic::initializeGraphs() {
         {7, 35, 20, 3, cbt_labels[10]},
         {8, 5, 20, 5, cbt_labels[11]}
     };
-    g2.edges = {{1, 2}, {1, 8}, {2, 4}, {3, 4}, {4, 5}, {5, 7}, {6, 7}, {7, 8}};
+    g2.edges = std::vector<Edge>{{1, 2}, {1, 8}, {2, 4}, {3, 4}, {4, 5}, {5, 7}, {6, 7}, {7, 8}};
     graphs.push_back(g2);
 
     // NOTE: The following block was syntactically incorrect and referred to


### PR DESCRIPTION
…w` application, allowing it to be built successfully with g++.

The following cumulative changes were made to `quanta_tissu/nexus_flow/`:

- Corrected JSON API Usage: Updated `graph_logic.cpp` to use the correct methods from the custom JSON library (`json.h`). This involved replacing incorrect calls for type checking (`.type()`), object access (`[]`), and number conversion (`.as_integer()`) with the correct API (`.is_object()`, `.as_object().at()`, `static_cast<int>(.as_number())`).

- Added Missing Function Declaration: Added the declaration for `initializeGraphs()` to the `graph_logic.h` header file to resolve a "not declared in this scope" error.

- Removed Erroneous Code: Deleted a syntactically incorrect and non-functional `try-catch` block from the end of `initializeGraphs` in `graph_logic.cpp`.

- Fixed Vector Initialization: Modified the initialization of `std::vector` for nodes and edges in `graph_logic.cpp` to be more explicit (e.g., `std::vector<Node>{...}`). This resolves a compilation failure on stricter compilers.