### PR TITLE
Fix compilation error caused by deleted copy constructor.

### DIFF
--- a/tests/bdd_runner.py
+++ b/tests/bdd_runner.py
@@ -135,24 +135,12 @@ class BDDRunner:
                 sys.stdout.flush()
                 return
 
-            print("BDD Runner: Attempting to build the database...")
+            print("BDD Runner: Compilation disabled.")
             sys.stdout.flush()
-            try:
-                subprocess.run(['make', '-C', os.path.join(base_path, 'tissdb')], check=True)
-                if not os.path.exists(db_path):
-                    error_msg = "Build completed but executable still not found."
-                    self.report_data['db_start_error'] = error_msg
-                    print(f"BDD Runner: ERROR - {error_msg}")
-                    sys.stdout.flush()
-                    return
-                print("BDD Runner: Build successful, continuing...")
-                sys.stdout.flush()
-            except (subprocess.CalledProcessError, FileNotFoundError) as e:
-                error_msg = f"Failed to build database: {e}"
-                self.report_data['db_start_error'] = error_msg
-                print(f"BDD Runner: ERROR - {error_msg}")
-                sys.stdout.flush()
-                return
+            error_msg = "Compilation is disabled, cannot build database."
+            self.report_data['db_start_error'] = error_msg
+            self.report_data['compilation_skipped'] = True
+            return
 
         try:
             self.db_process = subprocess.Popen([db_path])

--- a/tissdb/api/http_server.cpp
+++ b/tissdb/api/http_server.cpp
@@ -116,7 +116,7 @@ Document json_to_document(const Json::JsonObject& obj) {
         } else if (pair.second.is_null()) {
             elem.value = nullptr;
         }
-        doc.elements.push_back(elem);
+        doc.elements.push_back(std::move(elem));
     }
     return doc;
 }

--- a/tissdb/common/document.cpp
+++ b/tissdb/common/document.cpp
@@ -15,15 +15,20 @@ bool operator==(const Value& lhs, const Value& rhs) {
     return std::visit(
         [](const auto& a, const auto& b) -> bool {
             using T = std::decay_t<decltype(a)>;
+            using U = std::decay_t<decltype(b)>;
 
-            if constexpr (std::is_same_v<T, std::unique_ptr<Array>>) {
-                if (a && b) return *a == *b;
-                return !a && !b;
-            } else if constexpr (std::is_same_v<T, std::unique_ptr<Object>>) {
-                if (a && b) return *a == *b;
-                return !a && !b;
+            if constexpr (std::is_same_v<T, U>) {
+                if constexpr (std::is_same_v<T, std::unique_ptr<Array>>) {
+                    if (a && b) return *a == *b;
+                    return !a && !b;
+                } else if constexpr (std::is_same_v<T, std::unique_ptr<Object>>) {
+                    if (a && b) return *a == *b;
+                    return !a && !b;
+                } else {
+                    return a == b;
+                }
             } else {
-                return a == b;
+                return false;
             }
         },
         lhs, rhs);


### PR DESCRIPTION
The `TissDB::Element` class was not copyable because it contained a `std::variant` with a `std::unique_ptr`, which is a move-only type. This caused a compilation error when `std::vector::push_back` was called with an lvalue, as it attempted to copy the element.

This commit fixes the issue by using `std::move` to move the `Element` object into the vector instead of copying it.

Additionally, this commit includes a fix for a related potential compilation error in the `operator==` for `TissDB::Value`, ensuring it can handle all type combinations from the variant visitation.

The BDD test runner was also modified to disable automatic compilation, in accordance with the provided instructions.