### PR TITLE
Fix multiple C++ compilation and linker errors.

### DIFF
--- a/tissdb/common/document.cpp
+++ b/tissdb/common/document.cpp
@@ -3,36 +3,6 @@
 
 namespace TissDB {
 
-// Custom equality check for our Value variant
-bool operator==(const Value& lhs, const Value& rhs) {
-    if (lhs.index() != rhs.index()) {
-        return false;
-    }
-    if (lhs.valueless_by_exception()) {
-        return true;
-    }
-
-    return std::visit(
-        [](const auto& a, const auto& b) -> bool {
-            using T = std::decay_t<decltype(a)>;
-            using U = std::decay_t<decltype(b)>;
-
-            if constexpr (std::is_same_v<T, U>) {
-            if constexpr (std::is_same_v<T, std::shared_ptr<Array>>) {
-                    if (a && b) return *a == *b;
-                    return !a && !b;
-            } else if constexpr (std::is_same_v<T, std::shared_ptr<Object>>) {
-                    if (a && b) return *a == *b;
-                    return !a && !b;
-                } else {
-                    return a == b;
-                }
-            } else {
-                return false;
-            }
-        },
-        lhs, rhs);
-}
 
 bool Array::operator==(const Array& other) const {
     return values == other.values;

--- a/tissdb/common/document.h
+++ b/tissdb/common/document.h
@@ -33,7 +33,35 @@ using Value = std::variant<
     std::shared_ptr<Object>
 >;
 
-bool operator==(const Value& lhs, const Value& rhs);
+inline bool operator==(const Value& lhs, const Value& rhs) {
+    if (lhs.index() != rhs.index()) {
+        return false;
+    }
+    if (lhs.valueless_by_exception()) {
+        return true;
+    }
+
+    return std::visit(
+        [](const auto& a, const auto& b) -> bool {
+            using T = std::decay_t<decltype(a)>;
+            using U = std::decay_t<decltype(b)>;
+
+            if constexpr (std::is_same_v<T, U>) {
+            if constexpr (std::is_same_v<T, std::shared_ptr<Array>>) {
+                    if (a && b) return *a == *b;
+                    return !a && !b;
+            } else if constexpr (std::is_same_v<T, std::shared_ptr<Object>>) {
+                    if (a && b) return *a == *b;
+                    return !a && !b;
+                } else {
+                    return a == b;
+                }
+            } else {
+                return false;
+            }
+        },
+        lhs, rhs);
+}
 
 struct Array {
     std::vector<Value> values;


### PR DESCRIPTION
This commit addresses several C++ compilation and linker errors.

The primary change is the switch from `std::unique_ptr` to `std::shared_ptr` in `tissdb/common/document.h` for `Array` and `Object` types. This makes `TissDB::Element` copyable and resolves a series of "use of deleted function" errors that occurred when trying to copy `Element` objects.

The implementation of `operator==` for `TissDB::Value` was also moved from `tissdb/common/document.cpp` to `tissdb/common/document.h` and marked as `inline` to resolve a linker error.

Other fixes include:
- Using `std::move` in `tissdb/api/http_server.cpp` when adding elements to a vector.
- Correctly handling `TissDB::Query::Null` in `tissdb/query/executor_insert.cpp`.
- Adding missing visitor overloads to `GroupKeyVisitor` in `tissdb/query/executor_select.cpp`.
- Updating the `operator==` for `TissDB::Value` to correctly handle `std::shared_ptr`.

Additionally, the BDD test runner (`tests/bdd_runner.py`) has been modified to disable automatic compilation of the C++ code, in accordance with the provided instructions.