### PR TITLE
Fix btree mess by replacing unlicensed B-tree with a native implement…

### DIFF
--- a/tissdb/storage/indexer.cpp
+++ b/tissdb/storage/indexer.cpp
@@ -204,7 +204,7 @@ std::vector<std::string> Indexer::find_by_index(const std::vector<std::string>& 
     std::vector<std::string> all_doc_ids;
     const auto& btree = it->second;
 
-    btree->foreach([&all_doc_ids](const std::string& key, const std::string& value) {
+    btree->foreach([&all_doc_ids](const std::string& /*key*/, const std::string& value) {
         try {
             Json::JsonArray ids_array = Json::JsonValue::parse(value).as_array();
             for (const auto& id_val : ids_array) {

--- a/tissdb/storage/native_b_tree.cpp
+++ b/tissdb/storage/native_b_tree.cpp
@@ -392,25 +392,6 @@ std::unique_ptr<typename BTree<Key, Value, Order>::BTreeNode> BTree<Key, Value, 
 // Explicit template instantiation
 template class BTree<std::string, std::string>;
 
-template<typename Key, typename Value, int Order>
-template<typename Func>
-void BTree<Key, Value, Order>::foreach_recursive(BTreeNode* node, Func& func) {
-    if (node->is_leaf) {
-        for (size_t i = 0; i < node->keys.size(); ++i) {
-            func(node->keys[i], node->values[i]);
-        }
-    } else {
-        for (size_t i = 0; i < node->children.size(); ++i) {
-            foreach_recursive(node->children[i].get(), func);
-        }
-    }
-}
-
-template<typename Key, typename Value, int Order>
-template<typename Func>
-void BTree<Key, Value, Order>::foreach(Func func) {
-    foreach_recursive(root_.get(), func);
-}
 
 } // namespace Storage
 } // namespace TissDB

--- a/tissdb/storage/native_b_tree.h
+++ b/tissdb/storage/native_b_tree.h
@@ -66,7 +66,22 @@ private:
     void foreach_recursive(BTreeNode* node, Func& func);
 public:
     template<typename Func>
-    void foreach(Func func);
+    void foreach(Func func) {
+        foreach_recursive(root_.get(), func);
+    }
+private:
+    template<typename Func>
+    void foreach_recursive(BTreeNode* node, Func& func) {
+        if (node->is_leaf) {
+            for (size_t i = 0; i < node->keys.size(); ++i) {
+                func(node->keys[i], node->values[i]);
+            }
+        } else {
+            for (size_t i = 0; i < node->children.size(); ++i) {
+                foreach_recursive(node->children[i].get(), func);
+            }
+        }
+    }
 };
 
 } // namespace Storage


### PR DESCRIPTION
…ation.

This commit addresses the "btree mess" by removing the unlicensed third-party B-tree implementation and replacing it with a new, native B-tree.

The key changes are:
- A new, fully functional B-tree has been implemented in `tissdb/storage/native_b_tree.h` and `tissdb/storage/native_b_tree.cpp`. This implementation includes insert, find, erase, and serialization capabilities.
- The unlicensed B-tree files (`BPTree.h`, `bpp_tree.h`, `bpp_tree_wrapper.h`, `Comp.h`, `Utils.h`) have been deleted.
- The `tissdb/storage/indexer` has been updated to use the new native B-tree implementation.
- The test file `tests/db/test_bpp_tree.cpp` has been renamed to `tests/db/test_native_b_tree.cpp` and updated to use the new native B-tree implementation.
- The main test runner `tests/db/test_main.cpp` has been updated to include the new test file.
- All references to the old B-tree implementation have been removed from the documentation.
- A compilation error related to template instantiation of the `foreach` method has been fixed by moving its implementation to the header file.