### PR TITLE
Fix btree mess by replacing unlicensed B-tree with a native implement…

### DIFF
--- a/tissdb/storage/native_b_tree.h
+++ b/tissdb/storage/native_b_tree.h
@@ -62,8 +62,6 @@ private:
     std::string read_string(std::istream& is);
 
     // Iteration helper
-    template<typename Func>
-    void foreach_recursive(BTreeNode* node, Func& func);
 public:
     template<typename Func>
     void foreach(Func func) {


### PR DESCRIPTION
…ation.

This commit addresses the "btree mess" by removing the unlicensed third-party B-tree implementation and replacing it with a new, native B-tree.

The key changes are:
- A new, fully functional B-tree has been implemented in `tissdb/storage/native_b_tree.h` and `tissdb/storage/native_b_tree.cpp`. This implementation includes insert, find, erase, and serialization capabilities.
- The unlicensed B-tree files (`BPTree.h`, `bpp_tree.h`, `bpp_tree_wrapper.h`, `Comp.h`, `Utils.h`) have been deleted.
- The `tissdb/storage/indexer` has been updated to use the new native B-tree implementation.
- The test file `tests/db/test_bpp_tree.cpp` has been renamed to `tests/db/test_native_b_tree.cpp` and updated to use the new native B-tree implementation.
- The main test runner `tests/db/test_main.cpp` has been updated to include the new test file.
- All references to the old B-tree implementation have been removed from the documentation.
- A compilation error related to template instantiation of the `foreach` method has been fixed by moving its implementation to the header file.
- A compilation error related to a duplicate declaration of `foreach_recursive` has been fixed.