### PR TITLE
Expand TissLang parser with LOG command and comment preservation

### DIFF
--- a/quanta_tissu/tisslm/parser/matcher.py
+++ b/quanta_tissu/tisslm/parser/matcher.py
@@ -6,6 +6,7 @@ _PATTERNS = {
     'SETUP': re.compile(r'^\s*SETUP\s*\{\s*$'),
     'BLOCK_END': re.compile(r'^\s*\}\s*$'),
     'RUN': re.compile(r'^\s*RUN\s+([\'"])(.*?)\1\s*$'),
+    'LOG': re.compile(r'^\s*LOG\s+([\'"])(.*?)\1\s*$'),
     'WRITE': re.compile(r'^\s*WRITE\s+\"([^\"]+)\"\s+<<(\w+)\s*$'),
     'ASSERT': re.compile(r'^\s*ASSERT\s+(.+?)\s*$'),
     'READ': re.compile(r'^\s*READ\s+\"([^\"]+)\"\s+AS\s+([a-zA-Z_][a-zA-Z0-9_]*)\s*$'),


### PR DESCRIPTION
This change enhances the TissLang parser with two new features:

1.  A `LOG` command is added to the grammar and parser logic. This allows script authors to include `LOG "message"` statements within `STEP` or `SETUP` blocks for debugging purposes.

2.  The parser is modified to preserve comments in the Abstract Syntax Tree (AST). Previously, comments were discarded. Now, they are included as `COMMENT` nodes, making the AST a more faithful representation of the original script and aiding future tooling.