### PR TITLE
feat: Add output validator and integrate into model

### DIFF
--- a/quanta_tissu/tisslm/core/model.py
+++ b/quanta_tissu/tisslm/core/model.py
@@ -4,6 +4,7 @@ from .layers import MultiHeadAttention, FeedForward, LayerNorm, softmax
 from .knowledge_base import KnowledgeBase
 from .tokenizer import tokenize
 from .parameter import Parameter
+from .validators import validate_output
 
 class TransformerBlock:
     def __init__(self, d_model, num_heads, d_ff, name=""):
@@ -289,6 +290,10 @@ class QuantaTissu:
                 next_token_id = self.predict(token_ids_np, method=method, temperature=temperature, top_k=top_k, top_p=top_p)
                 generated_ids.append(next_token_id)
                 current_tokens.append(next_token_id)
+
+            if not validate_output(generated_ids):
+                return None
+
             return generated_ids
 
         # 1. Initialize cache for each layer
@@ -312,6 +317,11 @@ class QuantaTissu:
             next_token_id = self._predict_from_logits(logits[:, -1, :], method, temperature, top_k, top_p)
             generated_ids.append(next_token_id)
             
+        # 5. Validate the generated output
+        if not validate_output(generated_ids):
+            # If validation fails, return None to indicate a problem.
+            return None
+
         return generated_ids
 
     def predict(self, token_ids, method="greedy", temperature=1.0, top_k=None, top_p=None):

--- a/quanta_tissu/tisslm/core/validators.py
+++ b/quanta_tissu/tisslm/core/validators.py
@@ -1,0 +1,29 @@
+def validate_output(token_ids, max_ngram_repetition=3, ngram_size=3):
+    """
+    Validates the generated output to prevent simple failure modes like repetition.
+
+    Args:
+        token_ids (list[int]): The list of generated token IDs.
+        max_ngram_repetition (int): The maximum number of times an n-gram is allowed to repeat.
+        ngram_size (int): The size of the n-gram to check for repetition.
+
+    Returns:
+        bool: True if the output is valid, False otherwise.
+    """
+    if len(token_ids) < ngram_size:
+        return True  # Too short to have meaningful repetitions
+
+    ngrams = {}
+    for i in range(len(token_ids) - ngram_size + 1):
+        ngram = tuple(token_ids[i:i + ngram_size])
+        ngrams[ngram] = ngrams.get(ngram, 0) + 1
+
+    for ngram, count in ngrams.items():
+        if count > max_ngram_repetition:
+            print(f"--- VALIDATION FAILED ---")
+            print(f"Reason: The {ngram_size}-gram {list(ngram)} was repeated {count} times (max allowed: {max_ngram_repetition}).")
+            print(f"This indicates a potential 'Sleepicture' moment.")
+            print(f"-------------------------")
+            return False
+
+    return True


### PR DESCRIPTION
Introduces a new `validate_output` function to prevent common generation failure modes, such as n-gram repetition.

This validator is integrated into the `generate` method of the `QuantaTissu` model to ensure that generated token sequences are checked for quality before being returned. If validation fails, the generation process returns `None`.

The following changes are included:
- New file `quanta_tissu/tisslm/core/validators.py` with the `validate_output` function.
- Modified `quanta_tissu/tisslm/core/model.py` to import and use the new validator.