### PR TITLE
feat: Implement conditional IF/ELSE logic in TissLang parser

### DIFF
--- a/quanta_tissu/tisslm/parser/conditional.py
+++ b/quanta_tissu/tisslm/parser/conditional.py
@@ -1,0 +1,7 @@
+import re
+
+CONDITIONAL_PATTERNS = {
+    'IF': re.compile(r'^\s*IF\s+\"([^\"]+)\"\s*$'),
+    'ELSE': re.compile(r'^\s*ELSE\s*$'),
+    'ENDIF': re.compile(r'^\s*ENDIF\s*$'),
+}

--- a/quanta_tissu/tisslm/parser/setup.py
+++ b/quanta_tissu/tisslm/parser/setup.py
@@ -1,19 +1,19 @@
-from matcher import _PATTERNS
-from tisslang_parser import TissLangParserError
+from .matcher import _PATTERNS
 
-def handle_setup_command(line: str, ast: list, current_block: list, state: str, line_number: int) -> tuple[bool, str, list]:
+def handle_setup_command(line: str, ast: list, state_stack: list, block_stack: list, line_number: int) -> bool:
     """
-    Handles parsing of a SETUP command.
+    Handles parsing of a SETUP command, modifying stacks directly.
 
     Returns:
-        A tuple: (was_handled, new_state, new_current_block)
+        A boolean indicating if the command was handled.
     """
     setup_match = _PATTERNS['SETUP'].match(line)
     if setup_match:
         setup_node = {'type': 'SETUP', 'commands': []}
+        # A SETUP block is always at the top level
         ast.append(setup_node)
-        current_block = setup_node['commands']
-        # We can reuse the IN_STEP state as the allowed commands are identical
-        state = "IN_STEP"
-        return True, state, current_block
-    return False, state, current_block
+
+        state_stack.append("IN_STEP")
+        block_stack.append(setup_node['commands'])
+        return True
+    return False

--- a/quanta_tissu/tisslm/parser/step.py
+++ b/quanta_tissu/tisslm/parser/step.py
@@ -1,18 +1,19 @@
-from matcher import _PATTERNS
-from tisslang_parser import TissLangParserError
+from .matcher import _PATTERNS
 
-def handle_step_command(line: str, ast: list, current_block: list, state: str, line_number: int) -> tuple[bool, str, list]:
+def handle_step_command(line: str, ast: list, state_stack: list, block_stack: list, line_number: int) -> bool:
     """
-    Handles parsing of a STEP command.
+    Handles parsing of a STEP command, modifying stacks directly.
 
     Returns:
-        A tuple: (was_handled, new_state, new_current_block)
+        A boolean indicating if the command was handled.
     """
     step_match = _PATTERNS['STEP'].match(line)
     if step_match:
         step_node = {'type': 'STEP', 'description': step_match.group(1), 'commands': []}
+        # A STEP block is always at the top level
         ast.append(step_node)
-        current_block = step_node['commands']
-        state = "IN_STEP"
-        return True, state, current_block
-    return False, state, current_block
+
+        state_stack.append("IN_STEP")
+        block_stack.append(step_node['commands'])
+        return True
+    return False


### PR DESCRIPTION
This commit introduces support for conditional statements (`IF`, `ELSE`, `ENDIF`) in the TissLang language.

Key changes:
- Refactored the parser's state management from a single state variable to a state stack and a block stack to allow for the correct parsing of nested structures.
- Updated the `handle_step_command` and `handle_setup_command` helper functions to directly manage the state and block stacks, as per requirements.
- Added a new `conditional.py` file to define the regex patterns for the new conditional commands.
- Implemented the parsing logic for `IF`, `ELSE`, and `ENDIF` within `tisslang_parser.py`.
- Added a comprehensive suite of unit tests to `tests/test_tisslang_parser.py` to validate the new functionality, including nested conditionals and error handling.