### PR TITLE
This involved three files. First, I updated `tissdb/query/executor_co…

### DIFF
--- a/docs/tissql.ebnf
+++ b/docs/tissql.ebnf
@@ -1,4 +1,3 @@
-
 (* TissQL EBNF Grammar for TissDB *)
 
 query     ::= select_statement | insert_statement | update_statement | delete_statement
@@ -11,11 +10,11 @@ update_statement ::= "UPDATE" table_name "SET" set_clause (where_clause)?
 
 delete_statement ::= "DELETE" "FROM" table_name (where_clause)?
 
-select_list ::= "*" | column_list | aggregate_function_list
+select_list ::= "*" | select_item ("," select_item)*
 
-aggregate_function_list ::= aggregate_function ("," aggregate_function)*
+select_item ::= column_name | aggregate_function
 
-aggregate_function ::= ("COUNT" | "AVG" | "SUM" | "MIN" | "MAX") "(" IDENTIFIER ")"
+aggregate_function ::= "COUNT" "(" ("*" | IDENTIFIER) ")" | ("AVG" | "SUM" | "MIN" | "MAX") "(" IDENTIFIER ")"
 
 column_list ::= column_name ("," column_name)*
 

--- a/tissdb/query/ast.h
+++ b/tissdb/query/ast.h
@@ -39,10 +39,20 @@ struct LogicalExpression {
     Expression right;
 };
 
+// Represents the type of an aggregate function
+enum class AggregateType {
+    COUNT,
+    AVG,
+    SUM,
+    MIN,
+    MAX
+};
+
 // Represents an aggregate function call
 struct AggregateFunction {
-    std::string function_name;
-    std::string field_name;
+    AggregateType type;
+    // The field to aggregate on. nullopt represents '*' for COUNT(*).
+    std::optional<std::string> field_name;
 };
 
 // Forward declarations for recursive structures

--- a/tissdb/query/executor_common.h
+++ b/tissdb/query/executor_common.h
@@ -15,7 +15,8 @@ namespace Query {
 
 struct AggregateResult {
     double sum = 0;
-    int64_t count = 0;
+    int64_t count = 0; // For COUNT aggregate
+    int64_t avg_count = 0; // For AVG aggregate, only counts numeric values
     double sum_sq = 0;
     std::optional<double> min;
     std::optional<double> max;

--- a/tissdb/query/parser.h
+++ b/tissdb/query/parser.h
@@ -47,6 +47,7 @@ private:
     std::optional<JoinClause> parse_join_clause(); // Added for JOIN: JOIN collection ON condition
     std::optional<UnionClause> parse_union_clause(); // Added for UNION: SELECT ... UNION [ALL] SELECT ...
     std::optional<DrilldownClause> parse_drilldown_clause(); // Added for WITH DRILLDOWN
+    AggregateFunction parse_aggregate_function();
 
     Expression parse_expression(int precedence = 0);
     Expression parse_primary_expression();


### PR DESCRIPTION
…mmon.h` to add a field to the `AggregateResult` struct for correctly calculating averages. Second, I rewrote the `process_aggregation` function in `tissdb/query/executor_common.cpp` to work with the new AST structures and fix a bug in the original `AVG` logic. Finally, I refactored the entire aggregation and grouping section in `tissdb/query/executor_select.cpp`, adding a helper function and replacing the old logic with a new implementation that uses the updated AST nodes and function calls. I have verified the changes in all three files.