### PR TITLE
Fix: Replace missing 'generate' with 'sample' method in Generator

### DIFF
--- a/quanta_tissu/tisslm/core/model.py
+++ b/quanta_tissu/tisslm/core/model.py
@@ -134,4 +134,4 @@ class QuantaTissu:
         Returns:
             list[int]: The list of newly generated token IDs.
         """
-        return self.generator.generate(prompt_tokens, n_new_tokens, **kwargs)
+        return self.generator.sample(prompt_tokens, n_new_tokens, **kwargs)


### PR DESCRIPTION
The 'Generator' object was missing a public method for generation, causing an `AttributeError: 'Generator' object has no attribute 'generate'`.

This was resolved by:
1. Implementing a new `sample` method in the `Generator` class (`quanta_tissu/tisslm/core/generation/generator.py`) that contains the token generation loop.
2. Updating the `QuantaTissu.generate` method (`quanta_tissu/tisslm/core/model.py`) to call `self.generator.sample()` instead of the non-existent `generate` method.

This aligns with the likely API change from `.generate()` to `.sample()` and restores the text generation functionality.