### PR TITLE
fix(ide): Remove shlex from command parser

### DIFF
--- a/quanta_tissu/ide/p/menu.py
+++ b/quanta_tissu/ide/p/menu.py
@@ -1,4 +1,3 @@
-import shlex
 import os
 import re
 import glob
@@ -28,7 +27,7 @@ class CommandExecutor:
             self.recorded_macro.append(command_string)
 
         try:
-            parts = shlex.split(command_string)
+            parts = command_string.split()
             if not parts:
                 return
             command = parts[0]


### PR DESCRIPTION
Removes the `shlex` library from the command parser in `menu.py` and replaces its usage with `command_string.split()`.

This change was made at the user's explicit request to avoid using any libraries for command parsing.