### PR TITLE
feat: Implement persistence for database indexes

### DIFF
--- a/tissdb/storage/collection.h
+++ b/tissdb/storage/collection.h
@@ -20,7 +20,7 @@ class LSMTree; // Forward declaration
 // It is managed by the Database class.
 class Collection {
 public:
-    Collection(LSMTree* parent_db);
+    Collection(LSMTree* parent_db, const std::string& path = "");
     Collection(const std::string& path, LSMTree* parent_db);
 
     // Inserts or updates a document in the collection.
@@ -51,7 +51,9 @@ public:
 
     void set_schema(const TissDB::Schema& schema);
     void create_index(const std::vector<std::string>& field_names, bool is_unique = false);
-    void shutdown();
+
+    void save_indexes();
+    void load_indexes();
 
     // Indexer Wrappers
     bool has_index(const std::vector<std::string>& field_names) const;
@@ -69,6 +71,7 @@ private:
     TissDB::Schema schema_;
     Indexer indexer_;
     LSMTree* parent_db_; // Pointer to the parent database
+    std::string path_;
 };
 
 } // namespace Storage

--- a/tissdb/storage/lsm_tree.h
+++ b/tissdb/storage/lsm_tree.h
@@ -57,6 +57,9 @@ public:
     void shutdown();
 
 private:
+    void load_collections();
+    void save_collections();
+
     std::map<std::string, std::unique_ptr<Collection>> collections_;
     std::string path_;
     std::unique_ptr<WriteAheadLog> wal_;


### PR DESCRIPTION
Integrates the existing index serialization/deserialization logic into the database lifecycle.

The Indexer class already had complete `save_indexes` and `load_indexes` methods, but they were never called.

This commit introduces the following changes:
- The `Collection` class is now aware of its file path. It calls `load_indexes` on construction and `save_indexes` after a new index is created.
- The `LSMTree` class now orchestrates this by discovering and loading collections from disk on startup and triggering the save operation for all collections on shutdown.
- This ensures that all indexes are correctly persisted and reloaded, fulfilling the first stage of the indexing enhancement request.