### PR TITLE
docs: Update phase durations in hybrid plan

### DIFF
--- a/docs/tissos_hybrid_plan.md
+++ b/docs/tissos_hybrid_plan.md
@@ -1,0 +1,60 @@
+# Hybrid Strategy: From Plan B (Linux Distribution) to Plan A (New OS)
+
+## Phase 1: Establish TissOS via Plan B (Days 4-5)
+
+**Objective:** Deliver a functioning TissOS system quickly, validate user needs, and build community.
+
+*   **Base System:** Alpine Linux as foundation (musl libc, busybox, apk-tools).
+*   **Kernel Customization:** Apply targeted patches for security hardening, real-time extensions, and experimental hooks for TissDB integration.
+*   **Core Environment:**
+    *   Develop TissShell (custom shell interface) with hooks into TissDB.
+    *   Lightweight TissWM or custom desktop environment.
+    *   Begin TissApp ecosystem (TissMail, TissBrowser, etc.).
+*   **TissDB Integration:** Implement TissDB as a core service accessible across the OS (configuration, logging, state management).
+*   **Distribution Pipeline:** Automate builds with reproducible packaging (aports fork, CI/CD pipeline).
+
+**Deliverable:** A stable, branded Linux-based TissOS with unique UX and integrated TissDB.
+
+## Phase 2: Abstract System Services (Days 4-5)
+
+**Objective:** Gradually decouple from Linux internals while retaining compatibility.
+
+*   **Middleware Layer:** Introduce `tisssys` abstraction API for process management, IPC, file operations, and scheduling. Applications interact through `tisssys`, not directly with Linux syscalls.
+*   **Driver Layer Strategy:** Create `tissdrv` shim drivers that wrap Linux drivers, preparing for eventual replacement.
+*   **Security Sandbox:** Migrate critical services to isolated TissVM micro-environments to test microkernel concepts inside Linux.
+*   **TissDB Integration Expansion:** Extend TissDB to handle state persistence for services, replacing traditional config files.
+
+**Deliverable:** A Linux-based OS that already behaves partially like a microkernel system, with apps and services designed against TissOS abstractions.
+
+## Phase 3: Kernel Transition (Days 4-5)
+
+**Objective:** Introduce the first standalone TissOS microkernel prototype while maintaining Linux-based TissOS.
+
+*   **Microkernel Development:** Implement a minimal microkernel (process scheduling, memory management, IPC).
+*   **Dual Track Development:**
+    *   Maintain Plan B (Linux-based TissOS) for stability and community use.
+    *   Develop Plan A prototype in parallel, focusing on the `tisssys` abstraction layer so applications remain portable.
+*   **Subsystem Replacement:** Gradually migrate services from Linux kernel to TissOS microkernel equivalents (e.g., process manager, filesystem layer).
+*   **Compatibility Layer:** Run Linux binaries in a compatibility container until native TissOS apps dominate.
+
+**Deliverable:** Two variants:
+1.  Stable Linux-based TissOS for production.
+2.  Experimental microkernel TissOS using the same apps and abstractions.
+
+## Phase 4: Full Migration to Plan A (Days 4-5)
+
+**Objective:** Transition entirely to the microkernel-based TissOS.
+
+*   **Driver Ecosystem:** Replace Linux driver shims with native `TissDrv` implementations.
+*   **Native Filesystem:** Deploy TissFS optimized for integration with TissDB.
+*   **Service Migration:** All core services (networking, storage, windowing, security) run natively on TissOS microkernel.
+*   **Deprecation of Linux Base:** Linux distribution maintained only as legacy/compatibility layer.
+
+**Deliverable:** Fully independent TissOS with its own kernel, drivers, services, and ecosystem, evolved from Plan B foundations.
+
+## Strategic Benefits of Hybrid Approach
+
+*   **Feasibility:** Plan B ensures early deliverables and user adoption.
+*   **Continuity:** Abstraction layers allow seamless transition from Linux to TissOS microkernel.
+*   **Risk Management:** Two development tracks reduce the chance of failure.
+*   **Community Growth:** Users, developers, and applications build around TissOS early, smoothing the eventual migration.


### PR DESCRIPTION
Based on user feedback, this commit updates the estimated duration for each phase in the TissOS hybrid plan.

The timelines have been changed from multi-year estimates to "Days 4-5" for each phase to reflect the new, accelerated project schedule.