### PR TITLE
Fix BDD test suite issues

### DIFF
--- a/tests/features/steps/test_database_steps.py
+++ b/tests/features/steps/test_database_steps.py
@@ -28,6 +28,11 @@ def register_steps(runner):
         response = requests.put(f"{BASE_URL}/{context['db_name']}", headers=headers)
         assert response.status_code in [201, 200, 409], f"Failed to create database. Status: {response.status_code}, Body: {response.text}"
 
+    @runner.step(r'^Given a TissDB instance$')
+    def tissdb_instance(context):
+        # This is an alias for the "a running TissDB instance" step.
+        running_tissdb_instance(context)
+
     @runner.step(r'a collection named "(.*)"( exists)?')
     def collection_exists(context, collection_name, exists_word=None):
         context['collection_name'] = collection_name

--- a/tests/features/steps/test_select_queries_steps.py
+++ b/tests/features/steps/test_select_queries_steps.py
@@ -16,7 +16,8 @@ def register_steps(runner):
 
     @runner.step(r'^When I execute the TissQL query "(.*)"$')
     def execute_tissql_query_from_string(context, query_string):
-        match = re.search(r'(?:FROM|UPDATE|INSERT INTO)\s+(\w+)', query_string, re.IGNORECASE)
+        # This regex now handles INSERT with an optional INTO clause.
+        match = re.search(r'(?:FROM|UPDATE|INSERT(?: INTO)?)\s+([a-zA-Z0-9_]+)', query_string, re.IGNORECASE)
         if not match:
             assert match, f"Could not find collection name in query: {query_string}"
 


### PR DESCRIPTION
This commit addresses two critical issues in the BDD test suite:

1.  **Missing Step Definition**: Adds a step definition for `Given a TissDB instance` by aliasing an existing step. This resolves the 'step not found' warnings during test execution.
2.  **Query Parsing Bug**: Corrects the regular expression in the TissQL query execution step to properly handle `INSERT` statements where the `INTO` keyword is optional.

These changes prepare the test suite for execution in an environment where the `tissdb` executable is available.