### PR TITLE
feat: Implement Dropout, SwiGLU, RMSNorm, and RoPE

### DIFF
--- a/docs/enhancements.md
+++ b/docs/enhancements.md
@@ -9,11 +9,11 @@ Status Key: `[Not Started]` `[In Progress]` `[Done]`
 ### 1.1. Architectural Improvements
 -   **[Done] Multiple Transformer Blocks**: Generalize the model to allow stacking `N` transformer blocks, creating a deeper and more powerful model. This should be a configurable hyperparameter.
 -   **[Done] Causal Attention Mask**: Implement and apply a causal (look-ahead) mask in the attention mechanism. This is crucial for correct autoregressive behavior during training and efficient inference.
--   **[Not Started] Dropout Layers**: Add dropout layers after embeddings, attention, and feed-forward layers for regularization to prevent overfitting.
+-   **[Done] Dropout Layers**: Add dropout layers after embeddings, attention, and feed-forward layers for regularization to prevent overfitting.
 -   **[Done] Hyperparameter Configuration**: Centralize all model hyperparameters (e.g., `d_model`, `num_heads`, `d_ff`, `n_layers`, `vocab_size`) into a configuration object or file (e.g., `config.py` or a YAML file).
--   **[Not Started] Modern Feed-Forward Networks (SwiGLU)**: Replace the standard ReLU-based FFN with a more modern Gated Linear Unit variant like SwiGLU, which is used in models like Llama.
--   **[Not Started] Alternative Normalization (RMSNorm)**: Implement RMSNorm as a simpler and often faster alternative to standard Layer Normalization.
--   **[Not Started] Alternative Positional Encodings (RoPE)**: Replace sinusoidal positional encodings with a more modern approach like Rotary Positional Embeddings (RoPE).
+-   **[Done] Modern Feed-Forward Networks (SwiGLU)**: Replace the standard ReLU-based FFN with a more modern Gated Linear Unit variant like SwiGLU, which is used in models like Llama.
+-   **[Done] Alternative Normalization (RMSNorm)**: Implement RMSNorm as a simpler and often faster alternative to standard Layer Normalization.
+-   **[Done] Alternative Positional Encodings (RoPE)**: Replace sinusoidal positional encodings with a more modern approach like Rotary Positional Embeddings (RoPE).
 
 ### 1.2. Inference and Sampling
 -   **[Done] Batched Inference**: The model's forward pass already accepts a batch of prompts simultaneously.

--- a/quanta_tissu/tisslm/config.py
+++ b/quanta_tissu/tisslm/config.py
@@ -47,6 +47,7 @@ model_config = {
     "vocab_size": 8000,  # Will be set dynamically in run_training.py
     "block_size": tokenizer_config["max_len"], # Max sequence length for the model's internal processing.
     "layer_norm_eps": 1e-6, # Epsilon for Layer Normalization to prevent division by zero.
+    "dropout_rate": 0.1,  # The dropout rate for regularization.
     # Max length for positional encodings, tied to tokenizer's max length.
     "positional_encoding_max_len": tokenizer_config["max_len"],
 }

--- a/quanta_tissu/tisslm/core/generation/generator.py
+++ b/quanta_tissu/tisslm/core/generation/generator.py
@@ -43,7 +43,7 @@ class Generator:
 
         # First, process the entire prompt to populate the model's internal KV cache.
         prompt_array = np.array([current_tokens])
-        logits, _ = self.model.forward(prompt_array, start_pos=0)
+        logits, _ = self.model.forward(prompt_array, start_pos=0, training=False)
 
         for _ in range(n_new_tokens):
             last_logit = logits[:, -1, :]
@@ -67,7 +67,7 @@ class Generator:
             current_tokens.append(next_token)
 
             next_token_array = np.array([[next_token]])
-            logits, _ = self.model.forward(next_token_array, start_pos=len(current_tokens) - 1)
+            logits, _ = self.model.forward(next_token_array, start_pos=len(current_tokens) - 1, training=False)
 
         return generated_tokens
 

--- a/quanta_tissu/tisslm/core/layers.py
+++ b/quanta_tissu/tisslm/core/layers.py
@@ -17,6 +17,12 @@ def d_softmax(d_out, softmax_out, axis=-1):
 def d_relu(x, d_out):
     return d_out * (x > 0)
 
+def sigmoid(x):
+    return 1 / (1 + np.exp(-x))
+
+def d_sigmoid(d_out, sigmoid_out):
+    return d_out * sigmoid_out * (1 - sigmoid_out)
+
 class LayerNorm:
     """
     Applies Layer Normalization.
@@ -71,6 +77,118 @@ class LayerNorm:
         return [self.gamma, self.beta]
 
 
+class RMSNorm:
+    """
+    Applies Root Mean Square Layer Normalization.
+    """
+    def __init__(self, d_model, eps=1e-6, name=""):
+        self.eps = eps
+        self.gamma = Parameter(np.ones(d_model), name=f"{name}.gamma")
+
+    def __call__(self, x):
+        # Calculate the root mean square
+        rms = np.sqrt(np.mean(x**2, axis=-1, keepdims=True) + self.eps)
+        # Normalize and apply gain
+        x_norm = x / rms
+        out = self.gamma.value * x_norm
+
+        cache = {'x': x, 'rms': rms, 'x_norm': x_norm, 'gamma': self.gamma}
+        return out, cache
+
+    def backward(self, d_out, cache):
+        x, rms, x_norm, gamma = cache['x'], cache['rms'], cache['x_norm'], cache['gamma']
+
+        # Gradient for gamma
+        self.gamma.grad += np.sum(d_out * x_norm, axis=(0, 1))
+
+        # Gradient for x_norm
+        dx_norm = d_out * gamma.value
+
+        # Gradient for rms
+        drms = -np.sum(dx_norm * x / (rms**2), axis=-1, keepdims=True)
+
+        # Gradient for x
+        dx = dx_norm / rms
+        dx += drms * x / (x.shape[-1] * rms)
+
+        return dx
+
+    def parameters(self):
+        return [self.gamma]
+
+
+def precompute_rope_freqs(d_head, max_len, theta=10000.0):
+    """
+    Precomputes the RoPE frequencies (cos and sin values).
+    """
+    theta_numerator = np.arange(0, d_head, 2).astype(np.float32)
+    theta = 1.0 / (theta ** (theta_numerator / d_head))
+    m = np.arange(max_len)
+    freqs = np.outer(m, theta)
+    return np.cos(freqs), np.sin(freqs)
+
+def apply_rope(x, cos_freqs, sin_freqs):
+    """
+    Applies RoPE to the input tensor x.
+    """
+    # x shape: (batch, heads, seq_len, d_head)
+    seq_len = x.shape[2]
+
+    # Reshape x to treat pairs of features
+    x_reshaped = x.reshape(*x.shape[:-1], -1, 2)
+
+    # Split into real and imaginary parts (metaphorically)
+    x_real = x_reshaped[..., 0]
+    x_imag = x_reshaped[..., 1]
+
+    # Select frequencies for the given sequence length
+    cos = cos_freqs[:seq_len, :]
+    sin = sin_freqs[:seq_len, :]
+
+    # Add dimensions for broadcasting to batch and heads
+    cos = cos[np.newaxis, np.newaxis, :, :]
+    sin = sin[np.newaxis, np.newaxis, :, :]
+
+    # Apply rotation
+    x_rotated_real = x_real * cos - x_imag * sin
+    x_rotated_imag = x_real * sin + x_imag * cos
+
+    # Combine back
+    x_rotated = np.stack((x_rotated_real, x_rotated_imag), axis=-1)
+
+    # Reshape back to original d_head
+    return x_rotated.reshape(*x.shape)
+
+
+def backward_apply_rope(d_out, cos_freqs, sin_freqs):
+    """
+    Applies the backward pass for RoPE. This is equivalent to applying RoPE
+    with the negative angle.
+    """
+    # d_out shape: (batch, heads, seq_len, d_head)
+    seq_len = d_out.shape[2]
+
+    # Reshape d_out to treat pairs of features
+    d_out_reshaped = d_out.reshape(*d_out.shape[:-1], -1, 2)
+
+    d_real = d_out_reshaped[..., 0]
+    d_imag = d_out_reshaped[..., 1]
+
+    cos = cos_freqs[:seq_len, :]
+    sin = sin_freqs[:seq_len, :]
+
+    cos = cos[np.newaxis, np.newaxis, :, :]
+    sin = sin[np.newaxis, np.newaxis, :, :]
+
+    # Apply inverse rotation
+    dx_real = d_real * cos + d_imag * sin
+    dx_imag = -d_real * sin + d_imag * cos
+
+    dx_rotated = np.stack((dx_real, dx_imag), axis=-1)
+
+    return dx_rotated.reshape(*d_out.shape)
+
+
 def scaled_dot_product_attention(Q, K, V, mask=None):
     d_k = Q.shape[-1]
     scores = Q @ K.transpose(0, 1, 3, 2) / np.sqrt(d_k)
@@ -96,8 +214,7 @@ def backward_scaled_dot_product_attention(d_out, Q, K, V, scores, weights, mask=
 
 class MultiHeadAttention:
     """
-    Multi-Head Attention layer.
-    This version's forward pass returns a cache for backpropagation.
+    Multi-Head Attention layer with RoPE.
     """
     def __init__(self, d_model, num_heads, name=""):
         assert d_model % num_heads == 0
@@ -117,71 +234,84 @@ class MultiHeadAttention:
         batch_size, _, seq_len, _ = x.shape
         return x.transpose(0, 2, 1, 3).reshape(batch_size, seq_len, -1)
 
-    def __call__(self, x, mask=None, kv_cache=None):
+    def __call__(self, x, rope_freqs, mask=None, kv_cache=None):
+        cos_freqs, sin_freqs = rope_freqs
         Q = x @ self.Wq.value
         K_proj = x @ self.Wk.value
         V_proj = x @ self.Wv.value
+
         Qh, Kh_new, Vh_new = self.split_heads(Q), self.split_heads(K_proj), self.split_heads(V_proj)
+
+        # Apply RoPE
+        Qh_rot = apply_rope(Qh, cos_freqs, sin_freqs)
+        Kh_new_rot = apply_rope(Kh_new, cos_freqs, sin_freqs)
 
         if kv_cache is not None:
             if 'kh' in kv_cache:
-                Kh = np.concatenate([kv_cache['kh'], Kh_new], axis=2)
+                Kh_rot = np.concatenate([kv_cache['kh'], Kh_new_rot], axis=2)
                 Vh = np.concatenate([kv_cache['vh'], Vh_new], axis=2)
             else:
-                Kh, Vh = Kh_new, Vh_new
-            kv_cache['kh'], kv_cache['vh'] = Kh, Vh
+                Kh_rot, Vh = Kh_new_rot, Vh_new
+            kv_cache['kh'], kv_cache['vh'] = Kh_rot, Vh
         else:
-            Kh, Vh = Kh_new, Vh_new
+            Kh_rot, Vh = Kh_new_rot, Vh_new
         
-        attended, attention_weights = scaled_dot_product_attention(Qh, Kh, Vh, mask=mask)
+        attended, attention_weights = scaled_dot_product_attention(Qh_rot, Kh_rot, Vh, mask=mask)
         combined = self.combine_heads(attended)
         output = combined @ self.Wo.value
 
         cache = {
-            'x': x, 'Qh': Qh, 'Kh': Kh_new, 'Vh': Vh_new,
+            'x': x, 'Qh_rot': Qh_rot, 'Kh_rot': Kh_new_rot, 'Vh': Vh_new,
+            'rope_freqs': rope_freqs,
             'attention_weights': attention_weights, 'combined': combined,
             'Wq': self.Wq, 'Wk': self.Wk, 'Wv': self.Wv, 'Wo': self.Wo,
-            'layer_instance': self, # To access split_heads/combine_heads
-            'K_full': Kh, 'V_full': Vh, 'scores': Qh @ Kh.transpose(0, 1, 3, 2) / np.sqrt(Qh.shape[-1]) # Store full K, V for backward
+            'layer_instance': self,
+            'K_full_rot': Kh_rot, 'V_full': Vh, 'scores': Qh_rot @ Kh_rot.transpose(0, 1, 3, 2) / np.sqrt(Qh_rot.shape[-1])
         }
         return output, cache
 
     def backward(self, d_out, cache):
         x = cache['x']
-        Qh = cache['Qh']
-        Kh_full = cache['K_full'] # Use full K from cache
-        Vh_full = cache['V_full'] # Use full V from cache
+        Qh_rot = cache['Qh_rot']
+        Kh_full_rot = cache['K_full_rot']
+        Vh_full = cache['V_full']
         attention_weights = cache['attention_weights']
         combined = cache['combined']
-        Wq = cache['Wq']
-        Wk = cache['Wk']
-        Wv = cache['Wv']
-        Wo = cache['Wo']
+        rope_freqs = cache['rope_freqs']
+        cos_freqs, sin_freqs = rope_freqs
+
+        Wq, Wk, Wv, Wo = cache['Wq'], cache['Wk'], cache['Wv'], cache['Wo']
         scores = cache['scores']
         
         # 1. Gradient for Wo
-        self.Wo.grad += np.einsum('bsi,bsj->ij', combined, d_out)
+        self.Wo.grad += combined.reshape(-1, combined.shape[-1]).T @ d_out.reshape(-1, d_out.shape[-1])
 
-        # 2. Gradient for combined (output of combine_heads)
+        # 2. Gradient for combined
         d_combined = d_out @ Wo.value.T
 
-        # 3. Gradient for attended (input to combine_heads)
-        d_attended = self.split_heads(d_combined) # This is not correct, need to inverse combine_heads
-        # Correct inverse of combine_heads:
-        d_attended = d_combined.reshape(d_combined.shape[0], d_combined.shape[1], self.num_heads, self.d_k).transpose(0, 2, 1, 3)
+        # 3. Gradient for attended
+        d_attended = self.split_heads(d_combined)
 
-        # 4. Gradients for Q, K, V from scaled_dot_product_attention
-        d_Qh, d_Kh, d_Vh = backward_scaled_dot_product_attention(d_attended, Qh, Kh_full, Vh_full, scores, attention_weights)
+        # 4. Gradients for Q_rot, K_rot, V
+        d_Qh_rot, d_Kh_rot, d_Vh = backward_scaled_dot_product_attention(
+            d_attended, Qh_rot, Kh_full_rot, Vh_full, scores, attention_weights
+        )
 
-        # 5. Gradients for Wq, Wk, Wv
-        self.Wq.grad += np.einsum('bsi,bsj->ij', x, self.combine_heads(d_Qh))
-        self.Wk.grad += np.einsum('bsi,bsj->ij', x, self.combine_heads(d_Kh))
-        self.Wv.grad += np.einsum('bsi,bsj->ij', x, self.combine_heads(d_Vh))
+        # 5. Backpropagate through RoPE
+        d_Qh = backward_apply_rope(d_Qh_rot, cos_freqs, sin_freqs)
+        d_Kh = backward_apply_rope(d_Kh_rot, cos_freqs, sin_freqs)
 
-        # 6. Gradient for x (input to MHA)
-        dx = (self.combine_heads(d_Qh) @ Wq.value.T +
-              self.combine_heads(d_Kh) @ Wk.value.T +
-              self.combine_heads(d_Vh) @ Wv.value.T)
+        # 6. Gradients for Wq, Wk, Wv
+        d_Q = self.combine_heads(d_Qh)
+        d_K = self.combine_heads(d_Kh)
+        d_V = self.combine_heads(d_Vh)
+
+        self.Wq.grad += x.reshape(-1, x.shape[-1]).T @ d_Q.reshape(-1, d_Q.shape[-1])
+        self.Wk.grad += x.reshape(-1, x.shape[-1]).T @ d_K.reshape(-1, d_K.shape[-1])
+        self.Wv.grad += x.reshape(-1, x.shape[-1]).T @ d_V.reshape(-1, d_V.shape[-1])
+
+        # 7. Gradient for x (input to MHA)
+        dx = (d_Q @ Wq.value.T + d_K @ Wk.value.T + d_V @ Wv.value.T)
 
         return dx
 
@@ -190,50 +320,110 @@ class MultiHeadAttention:
 
 class FeedForward:
     """
-    A simple feed-forward network (FFN).
-    This version's forward pass returns a cache for backpropagation.
+    A SwiGLU (Swish-Gated Linear Unit) feed-forward network.
+    This version replaces the standard ReLU FFN.
     """
     def __init__(self, d_model, d_ff, name=""):
+        # d_ff is the inner dimension of the FFN.
+        # For SwiGLU, we often use two linear layers (one gated) followed by an output layer.
         self.W1 = Parameter(np.random.randn(d_model, d_ff) / np.sqrt(d_model), name=f"{name}.W1")
-        self.b1 = Parameter(np.zeros(d_ff), name=f"{name}.b1")
+        self.V1 = Parameter(np.random.randn(d_model, d_ff) / np.sqrt(d_model), name=f"{name}.V1") # Gating layer
         self.W2 = Parameter(np.random.randn(d_ff, d_model) / np.sqrt(d_ff), name=f"{name}.W2")
-        self.b2 = Parameter(np.zeros(d_model), name=f"{name}.b2")
 
     def __call__(self, x):
-        z = x @ self.W1.value + self.b1.value
-        h = np.maximum(0, z)
-        y = h @ self.W2.value + self.b2.value
+        # Forward pass: output = ((x @ W1) * sigmoid(x @ V1)) @ W2
+        gate_val = x @ self.V1.value
+        g = sigmoid(gate_val)
+        h = (x @ self.W1.value) * g
+        y = h @ self.W2.value
 
-        cache = {'x': x, 'z': z, 'h': h, 'W1': self.W1, 'b1': self.b1, 'W2': self.W2, 'b2': self.b2}
+        cache = {'x': x, 'g': g, 'h': h, 'gate_val': gate_val, 'W1': self.W1, 'V1': self.V1, 'W2': self.W2}
         return y, cache
 
     def backward(self, d_out, cache):
-        x = cache['x']
-        z = cache['z']
-        h = cache['h']
-        W1 = cache['W1']
-        b1 = cache['b1']
-        W2 = cache['W2']
-        b2 = cache['b2']
+        # Unpack cache
+        x, g, h, gate_val, W1, V1, W2 = \
+            cache['x'], cache['g'], cache['h'], cache['gate_val'], cache['W1'], cache['V1'], cache['W2']
 
-        # 1. Gradient for W2 and b2
-        self.W2.grad += np.einsum('bsf,bsd->fd', h, d_out)
-        self.b2.grad += np.sum(d_out, axis=(0, 1))
+        # 1. Gradient for W2
+        # dL/dW2 = dL/dy * dy/dW2 = h.T @ d_out
+        self.W2.grad += h.reshape(-1, h.shape[-1]).T @ d_out.reshape(-1, d_out.shape[-1])
 
         # 2. Gradient for h
+        # dL/dh = dL/dy * dy/dh = d_out @ W2.T
         dh = d_out @ W2.value.T
 
-        # 3. Gradient for z (through ReLU)
-        dz = d_relu(z, dh)
+        # 3. Gradient for g (from h = (x @ W1) * g)
+        # dL/dg = dL/dh * dh/dg = dh * (x @ W1)
+        dg = dh * (x @ W1.value)
 
-        # 4. Gradient for W1 and b1
-        self.W1.grad += np.einsum('bsd,bsf->df', x, dz)
-        self.b1.grad += np.sum(dz, axis=(0, 1))
+        # 4. Gradient for V1 (through sigmoid)
+        # dL/dV1 = dL/dg * dg/d(gate_val) * d(gate_val)/dV1
+        # dg/d(gate_val) is d_sigmoid(g)
+        d_gate_val = d_sigmoid(dg, g)
+        # d(gate_val)/dV1 = x.T
+        self.V1.grad += x.reshape(-1, x.shape[-1]).T @ d_gate_val.reshape(-1, d_gate_val.shape[-1])
 
-        # 5. Gradient for x (input to FFN)
-        dx = dz @ W1.value.T
+        # 5. Gradient for W1
+        # dL/dW1 = dL/dh * dh/d(x@W1) * d(x@W1)/dW1
+        # dL/dh * dh/d(x@W1) = dh * g
+        d_x_w1 = dh * g
+        self.W1.grad += x.reshape(-1, x.shape[-1]).T @ d_x_w1.reshape(-1, d_x_w1.shape[-1])
+
+        # 6. Gradient for x (input to FFN)
+        # The gradient dL/dx is the sum of gradients from the two paths where x is used:
+        # Path 1: Through the linear transformation (x @ W1)
+        # Path 2: Through the gating transformation (x @ V1)
+        # dL/dx = dL/d(x@W1) * d(x@W1)/dx + dL/d(x@V1) * d(x@V1)/dx
+        # dL/dx = (d_x_w1 @ W1.T) + (d_gate_val @ V1.T)
+        dx = (d_x_w1 @ W1.value.T) + (d_gate_val @ V1.value.T)
 
         return dx
 
     def parameters(self):
-        return [self.W1, self.b1, self.W2, self.b2]
+        return [self.W1, self.V1, self.W2]
+
+
+class Dropout:
+    """
+    Applies Dropout regularization.
+    """
+    def __init__(self, p=0.5):
+        if not (0 <= p < 1):
+            raise ValueError("Dropout probability must be in [0, 1)")
+        self.p = p
+        self.mask = None
+
+    def __call__(self, x, training=True):
+        """
+        Forward pass for Dropout.
+
+        Args:
+            x: The input data.
+            training: If True, applies dropout. Otherwise, returns the input untouched.
+
+        Returns:
+            The output after applying dropout and the cache for backpropagation.
+        """
+        if not training or self.p == 0:
+            self.mask = None
+            cache = {'mask': self.mask}
+            return x, cache
+
+        # Inverted dropout: scale up during training
+        self.mask = (np.random.rand(*x.shape) > self.p) / (1.0 - self.p)
+        out = x * self.mask
+        cache = {'mask': self.mask}
+        return out, cache
+
+    def backward(self, d_out, cache):
+        """
+        Backward pass for Dropout.
+        """
+        mask = cache.get('mask')
+        if mask is None: # If not in training mode or p=0
+            return d_out
+        return d_out * mask
+
+    def parameters(self):
+        return []

--- a/quanta_tissu/tisslm/core/training/trainer.py
+++ b/quanta_tissu/tisslm/core/training/trainer.py
@@ -39,10 +39,10 @@ class Trainer:
             logger.info(f"\n--- Epoch {epoch + 1}/{self.config['epochs']} ---")
             for x_batch, y_batch in self.dataset:
 
-                logits, cache = self.model.forward(x_batch)
+                logits, cache = self.model.forward(x_batch, training=True)
                 loss = self.loss_fn.forward(logits, y_batch)
                 d_logits = self.loss_fn.backward()
-                self._backward(d_logits, cache)
+                self.model.backward(d_logits, cache)
 
                 params = self.model.parameters()
                 grads = [p.grad for p in params if p.grad is not None]
@@ -66,99 +66,3 @@ class Trainer:
 
         logger.info("\n--- Training complete ---")
         save_checkpoint(self.model, self.optimizer, self.config["epochs"] - 1, step, self.config["checkpoint_dir"], keep_last=self.config.get("keep_checkpoints", -1))
-
-    def _backward(self, d_logits, model_cache):
-        final_x, output_proj, embeddings, token_ids, block_caches = \
-            model_cache['final_x'], model_cache['output_proj'], model_cache['embeddings'], model_cache['token_ids'], model_cache['block_caches']
-
-        batch_size, seq_len, d_model = final_x.shape
-        final_x_reshaped = final_x.reshape(batch_size * seq_len, d_model)
-        d_logits_reshaped = d_logits.reshape(batch_size * seq_len, -1)
-
-        output_proj.grad += final_x_reshaped.T @ d_logits_reshaped
-        dx = d_logits @ output_proj.value.T
-
-        for i in reversed(range(len(self.model.model.transformer_blocks))):
-            dx = self._backward_transformer_block(dx, block_caches[i])
-
-        d_embeddings = np.zeros_like(embeddings.value)
-        np.add.at(d_embeddings, token_ids, dx)
-        embeddings.grad += d_embeddings
-
-    def _backward_transformer_block(self, d_out, cache):
-        dx_plus_ffn = self._backward_layernorm(d_out, cache['ln2_cache'])
-        dx_norm1_from_ffn = self._backward_ffn(dx_plus_ffn, cache['ffn_cache'])
-        dx_norm1 = dx_plus_ffn + dx_norm1_from_ffn
-        dx_plus_attn = self._backward_layernorm(dx_norm1, cache['ln1_cache'])
-        dx_from_mha = self._backward_mha(dx_plus_attn, cache['mha_cache'])
-        return dx_plus_attn + dx_from_mha
-
-    def _backward_layernorm(self, d_out, cache):
-        x, x_norm, mean, var, gamma, beta, eps = \
-            cache['x'], cache['x_norm'], cache['mean'], cache['var'], cache['gamma'], cache['beta'], cache['eps']
-
-        D = x.shape[-1]
-        beta.grad += d_out.sum(axis=(0, 1))
-        gamma.grad += (d_out * x_norm).sum(axis=(0, 1))
-
-        dx_norm = d_out * gamma.value
-        dvar = np.sum(dx_norm * (x - mean) * -0.5 * (var + eps)**(-1.5), axis=-1, keepdims=True)
-        dmean = np.sum(dx_norm * -1 / np.sqrt(var + eps), axis=-1, keepdims=True) - 2 * dvar * np.sum(x - mean, axis=-1, keepdims=True) / D
-        return (dx_norm / np.sqrt(var + eps)) + (dvar * 2 * (x - mean) / D) + (dmean / D)
-
-    def _backward_ffn(self, d_out, cache):
-        x, z, h, W1, b1, W2, b2 = \
-            cache['x'], cache['z'], cache['h'], cache['W1'], cache['b1'], cache['W2'], cache['b2']
-
-        batch_size, seq_len, d_model = x.shape
-        d_ff = h.shape[-1]
-
-        h_reshaped = h.reshape(batch_size * seq_len, d_ff)
-        d_out_reshaped = d_out.reshape(batch_size * seq_len, d_model)
-        x_reshaped = x.reshape(batch_size * seq_len, d_model)
-
-        W2.grad += h_reshaped.T @ d_out_reshaped
-        b2.grad += d_out_reshaped.sum(axis=0)
-
-        dh = d_out @ W2.value.T
-        dz = dh * (z > 0)
-        dz_reshaped = dz.reshape(batch_size * seq_len, d_ff)
-
-        W1.grad += x_reshaped.T @ dz_reshaped
-        b1.grad += dz_reshaped.sum(axis=0)
-
-        return dz @ W1.value.T
-
-    def _backward_mha(self, d_out, cache):
-        x, Qh, Kh, Vh, attn_weights, combined, Wq, Wk, Wv, Wo, mha_instance = \
-            cache['x'], cache['Qh'], cache['Kh'], cache['Vh'], cache['attention_weights'], cache['combined'], \
-            cache['Wq'], cache['Wk'], cache['Wv'], cache['Wo'], cache['layer_instance']
-
-        batch_size, seq_len, d_model = x.shape
-
-        combined_reshaped = combined.reshape(batch_size * seq_len, d_model)
-        d_out_reshaped = d_out.reshape(batch_size * seq_len, d_model)
-
-        Wo.grad += combined_reshaped.T @ d_out_reshaped
-        d_combined = d_out @ Wo.value.T
-
-        d_attended = mha_instance.split_heads(d_combined)
-
-        d_weights = d_attended @ Vh.transpose(0, 1, 3, 2)
-        dVh = attn_weights.transpose(0, 1, 3, 2) @ d_attended
-
-        d_scores = d_weights # Simplified softmax backward
-        d_scores_unscaled = d_scores * np.sqrt(Qh.shape[-1])
-
-        dQh = d_scores_unscaled @ Kh
-        dKh_transposed = Qh.transpose(0, 1, 3, 2) @ d_scores_unscaled
-        dKh = dKh_transposed.transpose(0, 1, 3, 2)
-
-        dQ, dK, dV = mha_instance.combine_heads(dQh), mha_instance.combine_heads(dKh), mha_instance.combine_heads(dVh)
-
-        x_reshaped = x.reshape(batch_size * seq_len, d_model)
-        Wq.grad += x_reshaped.T @ dQ.reshape(-1, d_model)
-        Wk.grad += x_reshaped.T @ dK.reshape(-1, d_model)
-        Wv.grad += x_reshaped.T @ dV.reshape(-1, d_model)
-
-        return (dQ @ Wq.value.T) + (dK @ Wk.value.T) + (dV @ Wv.value.T)


### PR DESCRIPTION
This commit implements four major architectural enhancements to the core transformer model, replacing older components with modern alternatives.

1.  **Dropout Layers**: Adds a `Dropout` layer for regularization.
2.  **SwiGLU FFN**: Replaces the ReLU-based `FeedForward` layer with a SwiGLU implementation.
3.  **RMSNorm**: Replaces `LayerNorm` instances with `RMSNorm`.
4.  **RoPE**: Replaces sinusoidal positional encodings with Rotary Positional Embeddings.

Additionally, the `Trainer` class was refactored to delegate the backward pass to the model, simplifying the training loop and improving code modularity.

The `docs/enhancements.md` file has been updated to reflect the completion of these items.