### PR TITLE
Fixed the `TypeError` in `test_full_training_pipeline` by updating th…

### DIFF
--- a/tests/model/behavior/features/test_full_training_integration.py
+++ b/tests/model/behavior/features/test_full_training_integration.py
@@ -77,7 +77,14 @@ class TestFullTrainingIntegration(unittest.TestCase):
         # Configure mocks
         mock_system_config.__getitem__.side_effect = lambda key: {'model_save_path': self.config["model_save_path"]}[key]
         mock_tokenizer_system_config.__getitem__.side_effect = lambda key: {'model_save_path': self.config["model_save_path"]}[key]
+
+        # Configure model_config to handle both __getitem__ and get
+        def model_config_side_effect(key, default=None):
+            return self.config.get(key, default)
+
         mock_model_config.__getitem__.side_effect = lambda key: self.config[key]
+        mock_model_config.get.side_effect = model_config_side_effect
+
         mock_training_config.__getitem__.side_effect = lambda key: self.config[key]
         mock_tokenizer_config.__getitem__.side_effect = lambda key: self.config[key]
 


### PR DESCRIPTION
…e mock configuration to handle the `.get()` method.