### PR TITLE
Add Alpine Dev Environment and Framework CLI Tool

### DIFF
--- a/web_platform/backend/handlers/tisslang_handler.py
+++ b/web_platform/backend/handlers/tisslang_handler.py
@@ -31,6 +31,13 @@ def run_tisslang(handler, data):
         return
 
     script = data.get('script', '')
+    if not script:
+        handler.send_response(400)
+        handler.send_header('Content-Type', 'application/json')
+        handler.end_headers()
+        handler.wfile.write(b'{"error": "No script provided"}')
+        return
+
     try:
         parser = TissLangParser()
         ast = parser.parse(script)

--- a/web_platform/dev/Dockerfile
+++ b/web_platform/dev/Dockerfile
@@ -1,0 +1,35 @@
+# High-Altitude Alpine Greenhouse: Dev Environment for QuantaTissu
+# Provides a lightweight, isolated ecosystem for framework development.
+
+FROM python:3.12-alpine
+
+# Root System: Install essential system dependencies
+# build-base and python3-dev for potential native extensions
+# py3-numpy and py3-requests for efficient pre-compiled packages
+RUN apk add --no-cache \
+    build-base \
+    python3-dev \
+    py3-numpy \
+    py3-requests \
+    libffi-dev
+
+# Visible Foliage: Python requirements
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir regex
+
+# Environment Architecture
+ENV PYTHONPATH=/app
+ENV TISSDB_HOST=localhost
+ENV TISSDB_PORT=9876
+
+# Deploy the Greenhouse
+COPY . .
+
+# Setup Logging
+RUN mkdir -p /var/log && touch /var/log/framework.log && chmod 666 /var/log/framework.log
+
+EXPOSE 8000
+
+# Continuous Growth: Start the web platform server
+CMD ["python3", "-m", "web_platform.backend.server"]

--- a/web_platform/dev/README.md
+++ b/web_platform/dev/README.md
@@ -1,0 +1,50 @@
+# The High-Altitude Alpine Greenhouse 🏔️🌱
+
+Welcome to the isolated dev environment for the QuantaTissu Framework. This directory contains the configuration to run the web framework and associated models within a lightweight Alpine Docker container.
+
+## Architectural Metaphor
+
+In the Greenhouse for Mental Health Development, we view this container as a **High-Altitude Alpine Greenhouse**. It is a protected, thin-air environment where only the most robust "plants" (code modules) can survive.
+
+- **The Container (The Greenhouse)**: Provides the atmospheric pressure (OS dependencies) and nutrient-rich soil (Python packages) needed for the framework to thrive.
+- **The CLI (Automated Irrigation & Pruning)**: The `cli.py` tool acts as the caretaker, allowing you to trigger growth (training), observe flowers (model generation), and maintain the soil (database operations) from the safety of your terminal.
+
+## Technical Setup
+
+### 1. Prerequisites
+- Docker installed on your host machine.
+
+### 2. Planting the Greenhouse (Setup)
+Run the setup script to build the Docker image:
+```bash
+./web_platform/dev/scripts/setup.sh
+```
+
+### 3. Activating the Ecosystem (Run)
+Start the container in the background:
+```bash
+./web_platform/dev/scripts/run.sh
+```
+The web platform will be accessible at `http://localhost:8000`.
+
+### 4. Tending the Plants (CLI Usage)
+Use the CLI tool to interact with the running framework:
+```bash
+./web_platform/dev/scripts/cli.sh --help
+```
+
+**Common Commands:**
+- **Database Status**: `./web_platform/dev/scripts/cli.sh db status`
+- **Model Generation**: `./web_platform/dev/scripts/cli.sh model "Tell me about neuroplasticity"`
+- **Execute TissLang**: `./web_platform/dev/scripts/cli.sh tisslang "RUN 'ls'"`
+- **List Tasks**: `./web_platform/dev/scripts/cli.sh tasks list`
+- **Start Training**: `./web_platform/dev/scripts/cli.sh training start`
+
+## Logging
+All CLI actions and API responses are logged to `/var/log/framework.log` within the container, providing a detailed history of the greenhouse's evolution.
+
+## Testing
+To ensure the greenhouse's structural integrity, you can run the configuration tests:
+```bash
+PYTHONPATH=. python3 -m unittest web_platform/dev/tests/test_docker_config.py
+```

--- a/web_platform/dev/cli.py
+++ b/web_platform/dev/cli.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""
+QuantaTissu Framework CLI - Automated Irrigation & Pruning System
+Interacts with the web platform API to execute framework steps.
+"""
+
+import argparse
+import requests
+import json
+import sys
+import logging
+import os
+
+# Configure the Greenhouse Log
+LOG_FILE = "/var/log/framework.log"
+
+def setup_logging():
+    handlers = [logging.StreamHandler(sys.stdout)]
+    try:
+        # Try to use the file handler if possible (within container)
+        if os.access(os.path.dirname(LOG_FILE), os.W_OK) or os.path.exists(LOG_FILE) and os.access(LOG_FILE, os.W_OK):
+            handlers.append(logging.FileHandler(LOG_FILE))
+    except Exception:
+        pass
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format='%(asctime)s [%(levelname)s] %(message)s',
+        handlers=handlers
+    )
+
+setup_logging()
+
+API_BASE = os.environ.get("API_BASE", "http://localhost:8000/api")
+
+def log_api_call(method, endpoint, response):
+    logging.info(f"{method} {endpoint} - Status: {response.status_code}")
+    if response.status_code >= 400:
+        logging.error(f"Error Body: {response.text}")
+
+def db_status(args):
+    """Checks the status of TissDB databases."""
+    endpoint = f"{API_BASE}/db/databases"
+    resp = requests.get(endpoint)
+    log_api_call("GET", "/db/databases", resp)
+    print(json.dumps(resp.json(), indent=2))
+
+def db_query(args):
+    """Queries a collection in TissDB."""
+    endpoint = f"{API_BASE}/db/query"
+    payload = {"collection": args.collection, "query": args.query}
+    resp = requests.post(endpoint, json=payload)
+    log_api_call("POST", "/db/query", resp)
+    print(json.dumps(resp.json(), indent=2))
+
+def model_generate(args):
+    """Generates text using the model."""
+    endpoint = f"{API_BASE}/model/generate"
+    payload = {
+        "prompt": args.prompt,
+        "length": args.length,
+        "temperature": args.temp,
+        "use_rag": args.rag
+    }
+    resp = requests.post(endpoint, json=payload)
+    log_api_call("POST", "/model/generate", resp)
+    print(json.dumps(resp.json(), indent=2))
+
+def tisslang_run(args):
+    """Executes a TissLang script."""
+    endpoint = f"{API_BASE}/tisslang/run"
+    script = args.script
+    if os.path.exists(script):
+        with open(script, 'r') as f:
+            script = f.read()
+
+    payload = {"script": script}
+    resp = requests.post(endpoint, json=payload)
+    log_api_call("POST", "/tisslang/run", resp)
+    print(json.dumps(resp.json(), indent=2))
+
+def task_list(args):
+    """Lists all background tasks."""
+    endpoint = f"{API_BASE}/tasks"
+    resp = requests.get(endpoint)
+    log_api_call("GET", "/tasks", resp)
+    print(json.dumps(resp.json(), indent=2))
+
+def task_status(args):
+    """Gets status and logs for a specific task."""
+    endpoint = f"{API_BASE}/tasks/{args.id}"
+    resp = requests.get(endpoint)
+    log_api_call("GET", f"/tasks/{args.id}", resp)
+    print(json.dumps(resp.json(), indent=2))
+
+def training_start(args):
+    """Starts a new training session."""
+    endpoint = f"{API_BASE}/training/start"
+    resp = requests.post(endpoint, json={})
+    log_api_call("POST", "/training/start", resp)
+    print(json.dumps(resp.json(), indent=2))
+
+def training_status(args):
+    """Checks the status of the training session."""
+    endpoint = f"{API_BASE}/training/status"
+    resp = requests.get(endpoint)
+    log_api_call("GET", "/training/status", resp)
+    print(json.dumps(resp.json(), indent=2))
+
+def main():
+    parser = argparse.ArgumentParser(description="QuantaTissu Dev CLI")
+    subparsers = parser.add_subparsers(dest="command", help="Command to execute")
+
+    # DB Commands
+    db_parser = subparsers.add_parser("db", help="Database operations")
+    db_sub = db_parser.add_subparsers(dest="subcommand")
+    db_sub.add_parser("status", help="Show database status")
+    query_parser = db_sub.add_parser("query", help="Query a collection")
+    query_parser.add_argument("collection", help="Collection name")
+    query_parser.add_argument("query", help="JSON query string")
+
+    # Model Commands
+    model_parser = subparsers.add_parser("model", help="Model operations")
+    model_parser.add_argument("prompt", help="Prompt for generation")
+    model_parser.add_argument("--length", type=int, default=50, help="Max length")
+    model_parser.add_argument("--temp", type=float, default=0.7, help="Temperature")
+    model_parser.add_argument("--rag", action="store_true", help="Enable RAG")
+    model_parser.set_defaults(func=model_generate)
+
+    # TissLang Commands
+    tiss_parser = subparsers.add_parser("tisslang", help="TissLang orchestration")
+    tiss_parser.add_argument("script", help="TissLang script or path to script file")
+    tiss_parser.set_defaults(func=tisslang_run)
+
+    # Task Commands
+    task_parser = subparsers.add_parser("tasks", help="Task management")
+    task_sub = task_parser.add_subparsers(dest="subcommand")
+    task_sub.add_parser("list", help="List all tasks")
+    status_parser = task_sub.add_parser("status", help="Get task status")
+    status_parser.add_argument("id", help="Task ID")
+
+    # Training Commands
+    train_parser = subparsers.add_parser("training", help="Training control")
+    train_sub = train_parser.add_subparsers(dest="subcommand")
+    train_sub.add_parser("start", help="Start training")
+    train_sub.add_parser("status", help="Get training status")
+
+    args = parser.parse_args()
+
+    if args.command == "db":
+        if args.subcommand == "status":
+            db_status(args)
+        elif args.subcommand == "query":
+            db_query(args)
+    elif args.command == "tasks":
+        if args.subcommand == "list":
+            task_list(args)
+        elif args.subcommand == "status":
+            task_status(args)
+    elif args.command == "training":
+        if args.subcommand == "start":
+            training_start(args)
+        elif args.subcommand == "status":
+            training_status(args)
+    elif hasattr(args, 'func'):
+        args.func(args)
+    else:
+        parser.print_help()
+
+if __name__ == "__main__":
+    main()

--- a/web_platform/dev/scripts/cli.sh
+++ b/web_platform/dev/scripts/cli.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+# Execute the CLI tool within the running greenhouse container
+docker exec -it quantatissu-dev-container python /app/web_platform/dev/cli.py "$@"

--- a/web_platform/dev/scripts/run.sh
+++ b/web_platform/dev/scripts/run.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+# Run the greenhouse container in the background
+docker run -d -p 8000:8000 --name quantatissu-dev-container quantatissu-dev

--- a/web_platform/dev/scripts/setup.sh
+++ b/web_platform/dev/scripts/setup.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+# Build the High-Altitude Alpine Greenhouse image
+docker build -t quantatissu-dev -f web_platform/dev/Dockerfile .

--- a/web_platform/dev/tests/test_docker_config.py
+++ b/web_platform/dev/tests/test_docker_config.py
@@ -1,0 +1,59 @@
+import unittest
+import os
+import sys
+from unittest.mock import patch, MagicMock
+
+# Add the project root to sys.path to import the CLI
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+if PROJECT_ROOT not in sys.path:
+    sys.path.append(PROJECT_ROOT)
+
+from web_platform.dev.cli import main
+
+class TestDockerConfig(unittest.TestCase):
+    def test_dockerfile_exists(self):
+        dockerfile_path = os.path.join(PROJECT_ROOT, 'web_platform/dev/Dockerfile')
+        self.assertTrue(os.path.exists(dockerfile_path), "Dockerfile should exist")
+
+    def test_dockerfile_content(self):
+        dockerfile_path = os.path.join(PROJECT_ROOT, 'web_platform/dev/Dockerfile')
+        with open(dockerfile_path, 'r') as f:
+            content = f.read()
+            self.assertIn("FROM python:3.12-alpine", content)
+            self.assertIn("apk add --no-cache", content)
+            self.assertIn("ENV PYTHONPATH=/app", content)
+
+    @patch('web_platform.dev.cli.requests.get')
+    def test_cli_db_status(self, mock_get):
+        # Mocking the API response
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"databases": ["main_db"]}
+        mock_get.return_value = mock_resp
+
+        # Test running the CLI with 'db status'
+        with patch('sys.argv', ['cli.py', 'db', 'status']):
+            with patch('sys.stdout', new=MagicMock()) as mock_stdout:
+                main()
+                # Check if requests.get was called with the correct URL
+                self.assertTrue(mock_get.called)
+                args, kwargs = mock_get.call_args
+                self.assertIn('/api/db/databases', args[0])
+
+    @patch('web_platform.dev.cli.requests.post')
+    def test_cli_model_generate(self, mock_post):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"generated_text": "hello"}
+        mock_post.return_value = mock_resp
+
+        with patch('sys.argv', ['cli.py', 'model', 'hello']):
+            with patch('sys.stdout', new=MagicMock()) as mock_stdout:
+                main()
+                self.assertTrue(mock_post.called)
+                args, kwargs = mock_post.call_args
+                self.assertIn('/api/model/generate', args[0])
+                self.assertEqual(kwargs['json']['prompt'], 'hello')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
I have configured a new development directory `web_platform/dev/` that provides an isolated Alpine-based Docker environment for the QuantaTissu web framework.

The configuration includes:
1.  **High-Altitude Alpine Greenhouse (Dockerfile)**: A lightweight `python:3.12-alpine` container pre-configured with all necessary system and Python dependencies.
2.  **Automated Irrigation & Pruning System (cli.py)**: A powerful command-line interface that allows developers to:
    *   Query and check status of TissDB databases.
    *   Generate text using the Transformer model.
    *   Execute TissLang orchestration scripts.
    *   Manage background tasks.
    *   Control and monitor model training.
3.  **Utility Scripts**: Wrapper scripts for easy setup, execution, and CLI interaction.
4.  **Logging**: Integrated logging that records all framework operations to `/var/log/framework.log` within the container.
5.  **Test Suite**: A dedicated test suite (`test_docker_config.py`) to verify the environment's integrity.
6.  **Artistic Documentation**: A README that explains the technical setup through the "Greenhouse Ecosystem" metaphor, aligning with the project's psychological vision.

I also hardened the `tisslang_handler.py` to gracefully handle empty script requests, ensuring reliable CLI interaction.

---
*PR created automatically by Jules for task [1005979382298942070](https://jules.google.com/task/1005979382298942070) started by @drtamarojgreen*