### PR TITLE
Fix C++ Trainer compilation in integration runner

### DIFF
--- a/run_integration_api.py
+++ b/run_integration_api.py
@@ -4,6 +4,7 @@ import urllib.parse
 import json
 import time
 import sys
+import os
 
 SERVER_URL = "http://127.0.0.1:8000"
 
@@ -111,6 +112,7 @@ def main():
         "quanta_tissu/tisslm/program/training/optimizer.cpp "
         "quanta_tissu/tisslm/program/training/loss_function.cpp "
         "quanta_tissu/tisslm/program/training/trainer.cpp "
+        "quanta_tissu/tisslm/program/training/dataset.cpp "
         "quanta_tissu/tisslm/program/retrieval/retrieval_strategy.cpp "
         "tissdb/json/json.cpp "
         "-Itests/model/program -Iquanta_tissu/tisslm/program -Iquanta_tissu/tisslm/program/core "

--- a/tests/sdd/sorrel_checkins.md
+++ b/tests/sdd/sorrel_checkins.md
@@ -6,3 +6,12 @@
 - **Symptom**: No unified `task_id` for analyzer vs generic tasks.
 - **Constraint**: Java Orchestrator exists but currently only proxies back to Python for task listing.
 - **Goal**: Move canonical lifecycle ownership to Java, provide cursor-based logs, and unified API.
+
+## 2024-05-20 - C++ Trainer Compilation Failure
+- **Symptom**: `run_integration_api.py` fails at step [5/8] with "undefined reference to TissLM::Training::TokenDataset::TokenDataset".
+- **Root Cause**: `quanta_tissu/tisslm/program/training/dataset.cpp` is missing from the `g++` compilation command in `run_integration_api.py`.
+- **Goal**: Fix the compilation command to include the missing source file and verify full integration.
+- **Restrictions**:
+  - **Tooling**: Must use `g++` with `-std=c++17`.
+  - **Dependencies**: All TissLM program source files used in `train_model.cpp` must be explicitly listed in the compilation command.
+  - **Minimalism**: The compilation command must only include necessary files and flags to achieve a successful build.

--- a/tests/sdd/sorrel_checkouts.md
+++ b/tests/sdd/sorrel_checkouts.md
@@ -10,3 +10,9 @@
 - **Verification**: Cursor-based log retrieval implemented to ensure no gaps.
 - **Verification**: Executed SDD card `verify_process_lifecycle`; Result: `process_orchestrated = true`.
 - **Result**: "Lost process" symptoms resolved by centralizing state in a durable backend orchestrator and reactive frontend rehydration.
+
+## 2024-05-20 - C++ Trainer Compilation Fixed
+- **Implementation**: Added `quanta_tissu/tisslm/program/training/dataset.cpp` to the `compile_cmd` in `run_integration_api.py`.
+- **Implementation**: Added `import os` to `run_integration_api.py` to fix `os.path` reference in cleanup.
+- **Verification**: Executed `./run_integration_api.py`; all 8 steps completed successfully, including the C++ Trainer compilation and training process.
+- **Result**: Linker error "undefined reference to TissLM::Training::TokenDataset::TokenDataset" resolved.


### PR DESCRIPTION
This change resolves the linker error "undefined reference to TissLM::Training::TokenDataset" encountered during the C++ Model Training compilation step of the integration runner.

Key changes:
1. Updated `run_integration_api.py` to include `quanta_tissu/tisslm/program/training/dataset.cpp` in the `g++` compilation command.
2. Added `import os` to `run_integration_api.py` to support file-based cleanup operations.
3. Updated `tests/sdd/sorrel_checkins.md` to document the symptom, root cause, and restrictions for the fix.
4. Updated `tests/sdd/sorrel_checkouts.md` to record the implementation and successful verification of the full integration suite.

Verification:
The fix was empirically verified by executing `./run_integration_api.py` with the backend server running. All 8 steps of the integration suite completed successfully.

---
*PR created automatically by Jules for task [3217604349838672861](https://jules.google.com/task/3217604349838672861) started by @drtamarojgreen*